### PR TITLE
feat: add head_option method

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -197,6 +197,29 @@ class Arrays
     }
 
     /**
+     * 配列の最初の要素を取得します。空配列の場合は null を返します。
+     *
+     * 注意: 最初の要素が null の場合と空配列の場合を区別できません。
+     * 区別が必要な場合は empty($input) を事前にチェックしてください。
+     *
+     * @template K of array-key
+     * @template V
+     *
+     * @param list<V>|array<K, V> $input 対象の配列
+     * @return V|null 最初の要素、または配列が空の場合は null
+     */
+    public static function head_option(array $input): mixed
+    {
+        if (empty($input)) {
+            return null;
+        }
+
+        $firstKey = array_key_first($input);
+
+        return $input[$firstKey];
+    }
+
+    /**
      * 配列の最後の要素を取得します。空配列の場合は null を返します。
      *
      * 注意: 最後の要素が null の場合と空配列の場合を区別できません。

--- a/tests/HeadOptionTest.php
+++ b/tests/HeadOptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class HeadOptionTest extends TestCase
+{
+    public function testHeadOptionWithList(): void
+    {
+        $input  = [1, 2, 3];
+        $result = Arrays::head_option($input);
+
+        $this->assertSame(1, $result);
+    }
+
+    public function testHeadOptionWithAssoc(): void
+    {
+        $input  = ['a' => 1, 'b' => 2, 'c' => 3];
+        $result = Arrays::head_option($input);
+
+        $this->assertSame(1, $result);
+    }
+
+    public function testHeadOptionWithNumericAssoc(): void
+    {
+        $input  = [10 => 'a', 20 => 'b', 30 => 'c'];
+        $result = Arrays::head_option($input);
+
+        $this->assertSame('a', $result);
+    }
+
+    public function testHeadOptionWithSingleElement(): void
+    {
+        $input  = [42];
+        $result = Arrays::head_option($input);
+
+        $this->assertSame(42, $result);
+    }
+
+    public function testHeadOptionWithSingleElementAssoc(): void
+    {
+        $input  = ['key' => 'value'];
+        $result = Arrays::head_option($input);
+
+        $this->assertSame('value', $result);
+    }
+
+    public function testHeadOptionWithEmptyArray(): void
+    {
+        $input  = [];
+        $result = Arrays::head_option($input);
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertNull($result);
+    }
+
+    public function testHeadOptionWithNullValue(): void
+    {
+        $input  = [null, 1, 2];
+        $result = Arrays::head_option($input);
+
+        $this->assertNull($result);
+    }
+
+    public function testHeadOptionWithStringKeys(): void
+    {
+        $input  = ['first' => 'a', 'second' => 'b', 'third' => 'c'];
+        $result = Arrays::head_option($input);
+
+        $this->assertSame('a', $result);
+    }
+}


### PR DESCRIPTION
## Summary

Implemented `head_option()` method that returns the first element of an array, or null if the array is empty. This mirrors the existing `last_option()` method and is equivalent to Scala's headOption or PHP's array_first().

## Changes

- Added `Arrays::head_option()` method in `src/Arrays.php`
- Added comprehensive test suite in `tests/HeadOptionTest.php` with 8 test cases
- All tests pass and code follows project style guidelines

## Test Coverage

- Lists and associative arrays
- Numeric keys
- Single elements
- Empty arrays
- Null values
- String keys

Closes #18

Generated with [Claude Code](https://claude.ai/code)