### PR TITLE
feat: map_keys を実装

### DIFF
--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -258,12 +258,24 @@ class Arrays
      *
      * 注意: 複数のキーが同じ値に変換された場合、後のエントリの値が前のエントリを上書きします。
      *
+     * コールバックの引数順序について:
+     * この関数は「キーの変換」が主目的のため、コールバックは (key, value) の順で受け取ります。
+     * これは map() や filter() などの (value, key) 順とは異なります。
+     *
+     * ```php
+     * // ✅ 正しい使い方: 第1引数がキー、第2引数が値
+     * Arrays::map_keys($arr, fn(string $key, int $value): string => strtoupper($key));
+     *
+     * // ❌ 間違い: map() と同じ引数順序を期待している
+     * Arrays::map_keys($arr, fn(int $value, string $key): string => strtoupper($key));
+     * ```
+     *
      * @template K of array-key
      * @template V
      * @template R of array-key
      *
      * @param array<K, V> $input 対象の配列
-     * @param callable(K, V): R $callback キーを変換する関数
+     * @param callable(K, V): R $callback キーを変換する関数（第1引数: キー, 第2引数: 値）
      * @return array<R, V> キーが変換された新しい配列
      */
     public static function map_keys(array $input, callable $callback): array
@@ -271,7 +283,7 @@ class Arrays
         $result = [];
 
         foreach ($input as $key => $value) {
-            $newKey = $callback($key, $value);
+            $newKey          = $callback($key, $value);
             $result[$newKey] = $value;
         }
 

--- a/tests/MapKeysTest.php
+++ b/tests/MapKeysTest.php
@@ -87,7 +87,7 @@ final class MapKeysTest extends TestCase
 
         $result = Arrays::map_keys(
             $input,
-            fn (string $key, string $value): int => strlen($value),
+            fn (string $key, string $value): int => \strlen($value),
         );
 
         // Both values have length 5 and 4


### PR DESCRIPTION
## 概要

Kotlin の mapKeys 関数に相当する `map_keys` 関数を実装しました。
配列のキーを変換しつつ、値は保持します。

## 変更点

- `src/Arrays.php` に `map_keys` メソッドを追加
- `tests/MapKeysTest.php` にテストケースを追加
- キーの衝突時は後のエントリが前のエントリを上書きする仕様

## 動作確認

CI でテストが実行されます。

Fixes #24

Generated with [Claude Code](https://claude.ai/code)