### PR TITLE
mergeの実装, MergeTestの実装

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
             "src/head_option.php",
             "src/last_option.php",
             "src/intersect.php",
-            "src/map_keys.php"
+            "src/map_keys.php",
+            "src/merge.php"
         ]
     },
     "autoload-dev": {

--- a/src/merge.php
+++ b/src/merge.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 任意の数の配列を受け取り、1つの配列にして返します
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param array<list<V>|array<K, V>> $inputs
+ * @param Mode $mode MODE_AUTOのときは配列・連想配列の区別なくマージ。MODE_LISTのときは配列としてマージ。MODE_ASSOCのときはキーを維持して連想配列としてマージ。
+ * @return list<V>|array<K, V>
+ *
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V>:
+ *       ($inputs is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function merge(
+    array $inputs,
+    Mode $mode = Mode::MODE_AUTO,
+): array {
+    if (\count($inputs) <= 0) {
+        return [];
+    }
+
+    if ($mode === Mode::MODE_LIST) {
+        $result = [];
+
+        foreach ($inputs as $input) {
+            foreach ($input as $key => $value) {
+                $result[] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    if ($mode === Mode::MODE_ASSOC) {
+        return array_replace(...$inputs);
+    }
+
+    return array_merge(...$inputs);
+}

--- a/tests/MergeTest.php
+++ b/tests/MergeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class MergeTest extends TestCase
+{
+    public function testMergeWithEmptyWithAutoMode(): void
+    {
+        $result = merge([[], [], []]);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testMergeWithEmptyWithListMode(): void
+    {
+        $result = merge([[], [], []], Mode::MODE_LIST);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testMergeWithEmptyWithAssocMode(): void
+    {
+        $result = merge([[], [], []], Mode::MODE_ASSOC);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testMergeWithListInputWithAutoMode(): void
+    {
+        $input1 = [1, 2, 3];
+        $input2 = [3, 4, 5];
+
+        $result = merge([$input1, $input2]);
+
+        $this->assertSame([1, 2, 3, 3, 4, 5], $result);
+    }
+
+    public function testMergeWithStringKeyAssocInputWithAutoMode(): void
+    {
+        $input1 = ['a' => 1, 'b' => 2];
+        $input2 = ['b' => 3, 'c' => 4];
+
+        $result = merge([$input1, $input2]);
+
+        $this->assertSame(['a' => 1, 'b' => 3, 'c' => 4], $result);
+    }
+
+    public function testMergeWithNumberKeyAssocInputWithListMode(): void
+    {
+        $input1 = [1 => 'a', 2 => 'b', 4 => 'd'];
+        $input2 = [5 => 'e', 7 => 'g', 9 => 'i'];
+
+        $result = merge([$input1, $input2], Mode::MODE_LIST);
+
+        $this->assertSame([0 => 'a', 1 => 'b', 2 => 'd', 3 => 'e', 4 => 'g', 5 => 'i'], $result);
+    }
+
+    public function testMergeWithNumberKeyAssocInputWithAssocMode(): void
+    {
+        $input1 = [1 => 'a', 2 => 'b', 4 => 'd'];
+        $input2 = [5 => 'e', 7 => 'g', 9 => 'i'];
+
+        $result = merge([$input1, $input2], Mode::MODE_ASSOC);
+
+        $this->assertSame([1 => 'a', 2 => 'b', 4 => 'd', 5 => 'e', 7 => 'g', 9 => 'i'], $result);
+    }
+
+    public function testMergeWithMixKeyAssocInputWithAutoMode(): void
+    {
+        $input1 = [1, 2, 3, 4, 5];
+        $input2 = [3 => '4', 4 => '5'];
+        $input3 = ['f' => '6', 'g' => '7'];
+
+        $result = merge([$input1, $input2, $input3]);
+
+        $this->assertSame([1, 2, 3, 4, 5, '4', '5', 'f' => '6', 'g' => '7'], $result);
+    }
+
+    public function testMergeWithMixKeyAssocInputWithListMode(): void
+    {
+        $input1 = [1, 2, 3, 4, 5];
+        $input2 = [3 => '4', 4 => '5'];
+        $input3 = ['f' => '6', 'g' => '7'];
+
+        $result = merge([$input1, $input2, $input3], Mode::MODE_LIST);
+
+        $this->assertSame([1, 2, 3, 4, 5, '4', '5', '6', '7'], $result);
+    }
+
+    public function testMergeWithMixKeyAssocInputWithAssocMode(): void
+    {
+        $input1 = [1, 2, 3, 4, 5];
+        $input2 = [3 => '4', 4 => '5'];
+        $input3 = ['f' => '6', 'g' => '7'];
+
+        $result = merge([$input1, $input2, $input3], Mode::MODE_ASSOC);
+
+        $this->assertSame([1, 2, 3, '4', '5', 'f' => '6', 'g' => '7'], $result);
+    }
+}


### PR DESCRIPTION
#11 

array_mergeのラッパーとしてmergeを実装しました。
array_mergeでは可変長引数として配列を受け取れるように設計されていますが、mergeでは`$mode`との共存のため、配列の配列として渡す方式にしました。

### `$mode === Mode::MODE_AUTO`のとき
配列、連想配列の区別なく結合し、数字のキーはすべて番号が振りなおされ、文字列のキーは維持された状態でマージ結果を返します。

### `$mode === Mode::MODE_LIST`のとき
配列、連想配列は、すべてのキーが数字として振りなおされ、配列としてマージ結果を返します。

### `$mode === Mode::MODE_ASSOC`のとき
配列、連想配列は、キーを維持し重複したキーがある場合は上書きされ、連想配列としてマージ結果を返します。