### PR TITLE
feat: group_by を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "files": [
             "src/filter.php",
             "src/any.php",
+            "src/group_by.php",
             "src/tail.php",
             "src/init.php",
             "src/collect.php",

--- a/src/group_by.php
+++ b/src/group_by.php
@@ -24,9 +24,7 @@ function group_by(array $input, callable $classifier): array
     foreach ($input as $key => $value) {
         $groupKey = $classifier($value, $key);
 
-        if (!\array_key_exists($groupKey, $result)) {
-            $result[$groupKey] = [];
-        }
+        $result[$groupKey] ??= [];
 
         if ($isList) {
             $result[$groupKey][] = $value;

--- a/src/group_by.php
+++ b/src/group_by.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * コールバックで指定した分類キーごとに配列をグループ化します。
+ *
+ * @template K of array-key
+ * @template V
+ * @template G of array-key
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): G $classifier 分類キーを返す関数（第1引数: 値, 第2引数: キー）
+ * @return array<G, list<V>|array<K, V>>
+ * @phpstan-return ($input is list<V> ? array<G, list<V>> : array<G, array<K, V>>)
+ */
+function group_by(array $input, callable $classifier): array
+{
+    $result = [];
+    $isList = array_is_list($input);
+
+    foreach ($input as $key => $value) {
+        $groupKey = $classifier($value, $key);
+
+        if (!array_key_exists($groupKey, $result)) {
+            $result[$groupKey] = [];
+        }
+
+        if ($isList) {
+            $result[$groupKey][] = $value;
+        } else {
+            $result[$groupKey][$key] = $value;
+        }
+    }
+
+    return $result;
+}

--- a/src/group_by.php
+++ b/src/group_by.php
@@ -24,7 +24,7 @@ function group_by(array $input, callable $classifier): array
     foreach ($input as $key => $value) {
         $groupKey = $classifier($value, $key);
 
-        if (!array_key_exists($groupKey, $result)) {
+        if (!\array_key_exists($groupKey, $result)) {
             $result[$groupKey] = [];
         }
 

--- a/tests/GroupByTest.php
+++ b/tests/GroupByTest.php
@@ -14,7 +14,7 @@ final class GroupByTest extends TestCase
 
         $result = group_by(
             $input,
-            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+            fn ($value, $index): string => 'even',
         );
 
         $this->assertSame([], $result);

--- a/tests/GroupByTest.php
+++ b/tests/GroupByTest.php
@@ -49,6 +49,23 @@ final class GroupByTest extends TestCase
         ], $result);
     }
 
+    public function testGroupByWithIntegerGroupKeys(): void
+    {
+        $input = [10, 25, 30, 42];
+
+        $result = group_by(
+            $input,
+            fn (int $v, int $index): int => intdiv($v, 10),
+        );
+
+        $this->assertSame([
+            1 => [10],
+            2 => [25],
+            3 => [30],
+            4 => [42],
+        ], $result);
+    }
+
     public function testGroupByOnAssocInputPreservesKeysInEachGroup(): void
     {
         $input = [

--- a/tests/GroupByTest.php
+++ b/tests/GroupByTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class GroupByTest extends TestCase
+{
+    public function testGroupByOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = group_by(
+            $input,
+            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGroupByWithSingleGroupOnListInput(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = group_by(
+            $input,
+            fn (int $value, int $index): string => 'all',
+        );
+
+        $this->assertSame([
+            'all' => [1, 2, 3],
+        ], $result);
+    }
+
+    public function testGroupByWithMultipleGroupsOnListInputKeepsOrder(): void
+    {
+        $input = [3, 1, 4, 2, 5, 6];
+
+        $result = group_by(
+            $input,
+            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+        );
+
+        $this->assertSame([
+            'odd'  => [3, 1, 5],
+            'even' => [4, 2, 6],
+        ], $result);
+    }
+
+    public function testGroupByOnAssocInputPreservesKeysInEachGroup(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = group_by(
+            $input,
+            fn (int $age, string $name): string => $age >= 20 ? 'adult' : 'minor',
+        );
+
+        $this->assertSame([
+            'adult' => [
+                'alice' => 20,
+                'carol' => 23,
+            ],
+            'minor' => [
+                'bob'  => 17,
+                'dave' => 18,
+            ],
+        ], $result);
+    }
+}


### PR DESCRIPTION
Close #58.

- implement group_by(array $input, callable $classifier): array
- preserve input order within each group for both list and assoc input
- keep original keys for assoc input groups while appending for list input
- add GroupByTest for empty, single-group, multi-group, and assoc key preservation cases
- register src/group_by.php in composer autoload files