### PR TITLE
feat: chunk_by を追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
             "src/head_option.php",
             "src/last_option.php",
             "src/intersect.php",
-            "src/map_keys.php"
+            "src/map_keys.php",
+            "src/chunk_by.php"
         ]
     },
     "autoload-dev": {

--- a/src/chunk_by.php
+++ b/src/chunk_by.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 連続する要素を $callback の戻り値が等しい範囲ごとにまとめた配列の配列を返します。
+ *
+ * PHP 標準の `array_chunk` が指定サイズで等分するのに対し、 本関数は隣接する要素間で
+ * `$callback` の結果が変わる位置で chunk を切ります。 全要素数は保存され、 順序も維持されます。
+ *
+ * 例:
+ * ```
+ * chunk_by([1, 1, 2, 3, 3, 1], fn (int $v): int => $v);
+ * // => [[1, 1], [2], [3, 3], [1]]
+ * ```
+ *
+ * @template V
+ * @template R
+ *
+ * @param list<V> $input  対象の配列 (list 前提。 associative array は順序保証が無いため非対応)
+ * @param callable(V): R $callback  各要素を chunk キーに変換する。 戻り値は `===` で比較される。
+ * @return list<non-empty-list<V>>
+ */
+function chunk_by(array $input, callable $callback): array
+{
+    $chunks  = [];
+    $prevKey = null;
+
+    foreach ($input as $value) {
+        $key = $callback($value);
+
+        if ($chunks !== [] && $prevKey === $key) {
+            $chunks[\count($chunks) - 1][] = $value;
+        } else {
+            $chunks[] = [$value];
+            $prevKey  = $key;
+        }
+    }
+
+    return $chunks;
+}

--- a/tests/ChunkByTest.php
+++ b/tests/ChunkByTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class ChunkByTest extends TestCase
+{
+    public function testChunkByOnEmptyArrayReturnsEmpty(): void
+    {
+        $this->assertSame([], chunk_by([], fn ($v) => $v));
+    }
+
+    public function testChunkByWithSingleElementReturnsSingleChunk(): void
+    {
+        $this->assertSame([[42]], chunk_by([42], fn ($v) => $v));
+    }
+
+    public function testChunkByAllSameKeyReturnsSingleChunk(): void
+    {
+        $this->assertSame(
+            [[1, 3, 5]],
+            chunk_by([1, 3, 5], fn (int $v): int => $v % 2),
+        );
+    }
+
+    public function testChunkByAlternatingKeySplitsAtBoundary(): void
+    {
+        $this->assertSame(
+            [[1, 2], ['a', 'b'], [3]],
+            chunk_by([1, 2, 'a', 'b', 3], fn ($v): bool => \is_int($v)),
+        );
+    }
+
+    public function testChunkByMultipleKeysSplitsCorrectly(): void
+    {
+        $this->assertSame(
+            [[1, 1], [2], [3, 3, 3], [1]],
+            chunk_by([1, 1, 2, 3, 3, 3, 1], fn (int $v): int => $v),
+        );
+    }
+
+    public function testChunkByPreservesOrderInChunks(): void
+    {
+        // 各 chunk 内では入力順を保つ。
+        $this->assertSame(
+            [[3, 1], [4, 2], [5]],
+            chunk_by([3, 1, 4, 2, 5], fn (int $v): bool => $v % 2 !== 0),
+        );
+    }
+
+    public function testChunkByDoesNotMutateInput(): void
+    {
+        $input = [1, 2, 'a'];
+        $copy  = $input;
+
+        chunk_by($input, fn ($v): bool => \is_int($v));
+
+        $this->assertSame($copy, $input);
+    }
+}


### PR DESCRIPTION
## 概要

連続する要素を callback の戻り値が等しい範囲ごとにまとめた配列の配列を返す `chunk_by` を追加します。

PHP 標準の `array_chunk` が指定サイズで等分するのに対し、 本関数は隣接する要素間で callback の結果が変わる位置で chunk を切ります。

Scala の `List#groupAdjacent` / Haskell の `Data.List.groupBy` に相当する操作で、 「状態が切り替わる位置でランを区切る」 系の処理が一発で書けるようになります。

## Why

社内の dic.pixiv.net で TipTap ノード木の整形処理 (連続する illust 埋め込みを 1 つの block にまとめる等) で必要になり、 Phollection に欠けていたので追加。 既存の `group_by` (キーごとに非隣接でもまとめる) とは別の用途。

## 変更点

- `src/chunk_by.php` を追加
- `tests/ChunkByTest.php` に 7 ケース
  - 空配列
  - 単一要素
  - 全要素同キー
  - 二値での交替
  - 多値での分割
  - chunk 内の順序保証
  - 入力非破壊

## 動作確認

```
chunk_by([1, 1, 2, 3, 3, 1], fn (int $v): int => $v)
// => [[1, 1], [2], [3, 3], [1]]

chunk_by([1, 2, 'a', 'b', 3], fn ($v): bool => is_int($v))
// => [[1, 2], ['a', 'b'], [3]]
```

> [!NOTE]
> ローカルで PHP CS Fixer / PHPStan (level 10) / PHPUnit の 3 本とも pass することを確認済みです (`OK (104 tests, 109 assertions)` / PHPStan `[OK] No errors`)。 当初の本文にあった「vendor を install できなかった」注記は解消したため差し替えました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
