### PR TITLE
feat: sort_by を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/sort_by.php"
         ]
     },
     "autoload-dev": {

--- a/src/sort_by.php
+++ b/src/sort_by.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * $selector が返す比較キーの昇順で配列をソートします。
+ *
+ * 比較キー同士の比較には宇宙船演算子 `<=>` を使います。
+ * PHP 8.0 以降の usort / uasort は安定ソートであるため、比較キーが同値の要素は
+ * 入力順を維持します（安定ソート）。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): mixed $selector 比較キーを返す関数（第1引数: 値, 第2引数: キー）
+ * @return list<V>|array<K, V>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V>:
+ *       ($input is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function sort_by(array $input, callable $selector, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $entries = [];
+
+    foreach ($input as $key => $value) {
+        $entries[] = [
+            'key'      => $key,
+            'value'    => $value,
+            'sort_key' => $selector($value, $key),
+        ];
+    }
+
+    usort($entries, fn (array $a, array $b): int => $a['sort_key'] <=> $b['sort_key']);
+
+    if ($mode === Mode::MODE_ASSOC) {
+        $result = [];
+
+        foreach ($entries as $entry) {
+            $result[$entry['key']] = $entry['value'];
+        }
+
+        return $result;
+    }
+
+    return array_map(fn (array $entry) => $entry['value'], $entries);
+}

--- a/tests/SortByTest.php
+++ b/tests/SortByTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class SortByTest extends TestCase
+{
+    public function testSortByOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = sort_by(
+            $input,
+            fn ($value): mixed => $value,
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testSortByOnSingleElementReturnsSameElement(): void
+    {
+        $input = [42];
+
+        $result = sort_by(
+            $input,
+            fn (int $value): int => $value,
+        );
+
+        $this->assertSame([42], $result);
+    }
+
+    public function testSortByWithNumericKeyAscendsInOrder(): void
+    {
+        $input = [3, 1, 4, 1, 5, 9, 2, 6];
+
+        $result = sort_by(
+            $input,
+            fn (int $value): int => $value,
+        );
+
+        $this->assertSame([1, 1, 2, 3, 4, 5, 6, 9], $result);
+    }
+
+    public function testSortByWithStringKeyAscendsInOrder(): void
+    {
+        $input = ['banana', 'apple', 'cherry'];
+
+        $result = sort_by(
+            $input,
+            fn (string $value): string => $value,
+        );
+
+        $this->assertSame(['apple', 'banana', 'cherry'], $result);
+    }
+
+    public function testSortByWithEqualSortKeysKeepsInputOrder(): void
+    {
+        $input = [
+            ['name' => 'alice', 'priority' => 1],
+            ['name' => 'bob', 'priority' => 1],
+            ['name' => 'carol', 'priority' => 0],
+            ['name' => 'dave', 'priority' => 1],
+        ];
+
+        $result = sort_by(
+            $input,
+            fn (array $item): int => $item['priority'],
+        );
+
+        $this->assertSame([
+            ['name' => 'carol', 'priority' => 0],
+            ['name' => 'alice', 'priority' => 1],
+            ['name' => 'bob', 'priority' => 1],
+            ['name' => 'dave', 'priority' => 1],
+        ], $result);
+    }
+
+    public function testSortByOnAssocInputPreservesKeys(): void
+    {
+        $input = [
+            'carol' => 23,
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        $result = sort_by(
+            $input,
+            fn (int $age): int => $age,
+        );
+
+        $this->assertSame([
+            'bob'   => 17,
+            'alice' => 20,
+            'carol' => 23,
+        ], $result);
+    }
+
+    public function testSortByOnAssocInputWithModeListReindexesFromZero(): void
+    {
+        $input = [
+            'carol' => 23,
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        $result = sort_by(
+            $input,
+            fn (int $age): int => $age,
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([17, 20, 23], $result);
+    }
+
+    public function testSortBySelectorReceivesKeyAsSecondArgument(): void
+    {
+        $input = [
+            'carol' => 3,
+            'alice' => 1,
+            'bob'   => 2,
+        ];
+
+        $result = sort_by(
+            $input,
+            fn (int $value, string $key): string => $key,
+        );
+
+        $this->assertSame([
+            'alice' => 1,
+            'bob'   => 2,
+            'carol' => 3,
+        ], $result);
+    }
+
+    public function testSortByWithExplicitModeAssocKeepsOriginalKeys(): void
+    {
+        $input = [3, 1, 2];
+
+        $result = sort_by(
+            $input,
+            fn (int $value): int => $value,
+            Mode::MODE_ASSOC,
+        );
+
+        $this->assertSame([1 => 1, 2 => 2, 0 => 3], $result);
+    }
+
+    public function testSortByDoesNotMutateInputArray(): void
+    {
+        $input = [3, 1, 2];
+
+        sort_by(
+            $input,
+            fn (int $value): int => $value,
+        );
+
+        $this->assertSame([3, 1, 2], $input);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
selector が返す比較キーで昇順ソートする `sort_by` を追加します。
親 issue #56 の breakdown で挙がっていた基本操作で、`usort` のコンパレータを毎回書かずに済みます。

## 変更点
- `src/sort_by.php` — `<=>` で比較。ASSOC はキー保持、LIST は連番へ再付番
- `tests/SortByTest.php` — 10 ケース
- `composer.json` の `autoload.files` に 1 件追加

## 動作確認
- 手動：`sort_by(['carol' => 3, 'alice' => 1, 'bob' => 2], fn ($v, $k) => $k)` → `['alice' => 1, 'bob' => 2, 'carol' => 3]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (107 tests, 112 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 31 files`

## 補足（任意）
- **安定ソート**です。PHP 8.0 以降の `usort` / `uasort` が安定なので、比較キーが同値の要素は入力順を維持します (phpdoc に明記、テストで担保)。issue #72 の「安定性は仕様明記」要件への対応です
- `usort` は参照渡しなので、`{key, value, sort_key}` のエントリ配列を組み立ててからソートし、入力を破壊しません (テストで担保)
- selector は要素数と同じ回数だけ呼ばれます (比較キーを事前計算する実装)
- `@phpstan-param` の条件型は付けていません。付けると「assoc 入力 + `MODE_LIST`」が型エラーになるためで、`src/slice.php` / `src/map.php` / `src/intersect.php` と同じ形です

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
