### PR TITLE
feat: diff を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/diff.php"
         ]
     },
     "autoload-dev": {

--- a/src/diff.php
+++ b/src/diff.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * $input のうち $other に含まれない値だけを残します（差集合）。
+ *
+ * PHP の {@see array_diff()} のラッパーとして作られていますが、比較方法を意図的に変えています。
+ * array_diff() は要素を文字列化して比較するため、0 と '0'、1 と '1'、true と '1' を
+ * 同一視し、配列やオブジェクトを含む配列では警告や誤判定になります。本ライブラリは
+ * strict_types + PHPStan level 10 の型安全志向のため array_diff() には委譲せず、
+ * in_array() の厳密比較（===）モードで判定します。
+ *
+ * また、Scala の diff（multiset の差。要素の出現回数ぶんだけ取り除く）とは異なり、
+ * array_diff() と同じ集合としての差を返します。$input に重複した値がある場合、
+ * $other に含まれる値は重複分もすべて除去されます。
+ *
+ * $other のキーは見ず、値の集合としてのみ使用します。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param list<mixed>|array<array-key, mixed> $other 除外する値を持つ配列（キーは見ない）
+ * @return list<V>|array<K, V>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V> :
+ *       ($input is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function diff(array $input, array $other, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = [];
+
+    foreach ($input as $key => $value) {
+        if (\in_array($value, $other, true)) {
+            continue;
+        }
+
+        if ($mode === Mode::MODE_LIST) {
+            $result[] = $value;
+        } else {
+            $result[$key] = $value;
+        }
+    }
+
+    return $result;
+}

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class DiffTest extends TestCase
+{
+    public function testDiffOnBothEmptyArraysReturnsEmpty(): void
+    {
+        /** @var list<int> $input */
+        $input = [];
+        /** @var list<int> $other */
+        $other = [];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDiffWithEmptyOtherReturnsAllElements(): void
+    {
+        $input = [1, 2, 3];
+        /** @var list<int> $other */
+        $other = [];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([1, 2, 3], $result);
+    }
+
+    public function testDiffOnEmptyInputReturnsEmpty(): void
+    {
+        /** @var list<int> $input */
+        $input = [];
+        $other = [1, 2, 3];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDiffRemovesSomeElements(): void
+    {
+        $input = [1, 2, 3, 4];
+        $other = [2, 4];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([1, 3], $result);
+    }
+
+    public function testDiffRemovesAllElements(): void
+    {
+        $input = [1, 2, 3];
+        $other = [1, 2, 3, 4];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDiffDistinguishesZeroAndStringZero(): void
+    {
+        $input = [0, '0', 1, '1'];
+        $other = ['0', '1'];
+
+        $result = diff($input, $other);
+
+        // array_diff() なら '0'/'1' が 0/1 と同一視され全件除去されるが、
+        // 厳密比較では型の異なる 0 と 1 は残る
+        $this->assertSame([0, 1], $result);
+    }
+
+    public function testDiffDistinguishesTrueAndStringOne(): void
+    {
+        $input = [true, '1', false];
+        $other = ['1'];
+
+        $result = diff($input, $other);
+
+        // array_diff() なら true が '1' と同一視され除去されるが、
+        // 厳密比較では型の異なる true は残る
+        $this->assertSame([true, false], $result);
+    }
+
+    public function testDiffRemovesAllDuplicatesOfMatchedValue(): void
+    {
+        $input = [1, 2, 2, 3, 2];
+        $other = [2];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([1, 3], $result);
+    }
+
+    public function testDiffOnAssocInputPreservesKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+        $other = [2];
+
+        $result = diff($input, $other);
+
+        $this->assertSame(['a' => 1, 'c' => 3], $result);
+    }
+
+    public function testDiffOnAssocInputWithListModeReindexes(): void
+    {
+        $input = [
+            'a' => 10,
+            'b' => 20,
+            'c' => 30,
+        ];
+        $other = [20];
+
+        $result = diff($input, $other, Mode::MODE_LIST);
+
+        $this->assertSame([10, 30], $result);
+        $this->assertSame([0, 1], array_keys($result));
+    }
+
+    public function testDiffWithNullValues(): void
+    {
+        $input = [1, null, 2, null];
+        $other = [null];
+
+        $result = diff($input, $other);
+
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testDiffDoesNotMutateInput(): void
+    {
+        $input = [1, 2, 3, 4];
+        $other = [2, 4];
+
+        diff($input, $other);
+
+        $this->assertSame([1, 2, 3, 4], $input);
+    }
+
+    public function testDiffDoesNotMutateOther(): void
+    {
+        $input = [1, 2, 3, 4];
+        $other = [2, 4];
+
+        diff($input, $other);
+
+        $this->assertSame([2, 4], $other);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
`$other` に含まれない値だけを残す `diff` を追加します。

## 変更点
- `src/diff.php` — 厳密比較 (`===`) で判定。ASSOC はキー保持、LIST は連番へ再付番
- `tests/DiffTest.php` — 13 ケース
- `composer.json` の `autoload.files` に 1 件追加

## 動作確認
- 手動：`diff([0, 1, 2], ['0'])` → `[0, 1, 2]` (`array_diff` なら `[1, 2]`)
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (110 tests, 116 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 31 files`

## 補足（任意）

### `array_diff` に委譲していません

issue のタイトルは「`array_diff` のラッパー」ですが、意図的に外しました。`array_diff` は要素を文字列化して比較するため `0` と `'0'`、`1` と `'1'`、`true` と `'1'` を同一視し、配列やオブジェクトを含む入力では `Array to string conversion` が出ます。`declare(strict_types=1)` + PHPStan level 10 のこのライブラリでは厳密比較が妥当と判断しました。この差異は phpdoc に明記し、テストでも固定しています。

### `$other` の値型を `mixed` にしています

`intersect` に揃えて `@param list<V>|array<array-key, V> $other` と書くと、`diff([1,2,3], ['1','2'])` の戻り型が `list<1|2|3|'1'|'2'>` と実際 (`[1,2,3]`) より広く推論されることを `\PHPStan\dumpType()` で確認したため、`mixed` にしました。`diff` は「型の違う `$other` を渡して、違うから残る」使い方が本命なので、V を共有させると型が壊れます。

### 既存の `intersect` との非対称

`src/intersect.php` は LIST 側が `in_array($v, $other, false)` (緩い比較)、ASSOC 側が `array_intersect()` (文字列化比較) で、同じ関数の中で 2 つの比較規則が使われています。今回の `diff` が厳密比較なので現状は非対称です。`intersect` 側を揃えるかは別 issue で相談させてください。

### その他

- Scala の `diff` (multiset 差) ではなく `array_diff` と同じ集合差です (重複する値はまとめて除去)。phpdoc に明記
- `@phpstan-param` の条件型は付けていません (「assoc 入力 + `MODE_LIST`」が型エラーになるため。`slice.php` / `map.php` / `intersect.php` と同じ形)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
