### PR TITLE
feat: chunk と windowed を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/chunk.php"
+            "src/chunk.php",
+            "src/windowed.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/chunk.php"
         ]
     },
     "autoload-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 10
+    treatPhpDocTypesAsCertain: false
     paths:
         - src
         - tests

--- a/src/chunk.php
+++ b/src/chunk.php
@@ -11,13 +11,13 @@ namespace Oyashiro846\Phollection;
  * @template V
  *
  * @param list<V>|array<K, V> $input 対象の配列
- * @param int $size 1 つのチャンクに含める要素数（1 以上）
+ * @param positive-int $size 1 つのチャンクに含める要素数（1 以上）
  * @param Mode $mode MODE_LIST のときは各チャンク内を 0 始まりの連番にし、MODE_ASSOC のときは元のキーを保持する。MODE_AUTO のときは入力に応じて判定する
  * @throws \InvalidArgumentException $size が 1 未満のとき
- * @return list<list<V>|array<K, V>>
- * @phpstan-return ($mode is Mode::MODE_LIST ? list<list<V>> :
+ * @return list<non-empty-list<V>|array<K, V>> 空のチャンクは作らないので list 側は non-empty-list だが、assoc 側は non-empty-array<never, never> が解決できず空配列リテラルを渡す呼び出しを壊すため non-empty を付けない
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<non-empty-list<V>> :
  *     ($mode is Mode::MODE_ASSOC ? list<array<K, V>> :
- *       ($input is list<V> ? list<list<V>> :
+ *       ($input is list<V> ? list<non-empty-list<V>> :
  *         list<array<K, V>>
  *  )))
  */

--- a/src/chunk.php
+++ b/src/chunk.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列を固定サイズ単位で分割します。末尾は $size に満たない端数のチャンクになります。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param int $size 1 つのチャンクに含める要素数（1 以上）
+ * @param Mode $mode MODE_LIST のときは各チャンク内を 0 始まりの連番にし、MODE_ASSOC のときは元のキーを保持する。MODE_AUTO のときは入力に応じて判定する
+ * @throws \InvalidArgumentException $size が 1 未満のとき
+ * @return list<list<V>|array<K, V>>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<list<V>> :
+ *     ($mode is Mode::MODE_ASSOC ? list<array<K, V>> :
+ *       ($input is list<V> ? list<list<V>> :
+ *         list<array<K, V>>
+ *  )))
+ */
+function chunk(array $input, int $size, Mode $mode = Mode::MODE_AUTO): array
+{
+    if ($size <= 0) {
+        throw new \InvalidArgumentException('$size は 1 以上である必要があります。');
+    }
+
+    $mode = Mode::check_mode($mode, $input);
+
+    return array_chunk($input, $size, $mode === Mode::MODE_ASSOC);
+}

--- a/src/windowed.php
+++ b/src/windowed.php
@@ -22,15 +22,15 @@ namespace Oyashiro846\Phollection;
  * @template V
  *
  * @param list<V>|array<K, V> $input 対象の配列
- * @param int $size 1 つの窓に含める要素数（1 以上）
- * @param int $step 窓の開始位置を進める幅（1 以上）
+ * @param positive-int $size 1 つの窓に含める要素数（1 以上）
+ * @param positive-int $step 窓の開始位置を進める幅（1 以上）
  * @param bool $partial true のときは末尾の欠けた窓も返す
  * @param Mode $mode MODE_LIST のときは各窓内を 0 始まりの連番にし、MODE_ASSOC のときは元のキーを保持する。MODE_AUTO のときは入力に応じて判定する
  * @throws \InvalidArgumentException $size または $step が 1 未満のとき
- * @return list<list<V>|array<K, V>>
- * @phpstan-return ($mode is Mode::MODE_LIST ? list<list<V>> :
+ * @return list<non-empty-list<V>|array<K, V>> 空の窓は作らないので list 側は non-empty-list だが、assoc 側は non-empty-array<never, never> が解決できず空配列リテラルを渡す呼び出しを壊すため non-empty を付けない
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<non-empty-list<V>> :
  *     ($mode is Mode::MODE_ASSOC ? list<array<K, V>> :
- *       ($input is list<V> ? list<list<V>> :
+ *       ($input is list<V> ? list<non-empty-list<V>> :
  *         list<array<K, V>>
  *  )))
  */
@@ -62,6 +62,9 @@ function windowed(
         // キーを保持したまま切り出し、MODE_LIST のときだけ窓の中を連番へ振り直す
         // （array_slice は $preserve_keys が false でも文字列キーを維持するため）
         $window = \array_slice($input, $offset, $size, true);
+
+        // 開始位置は必ず件数未満で $size は 1 以上なので、窓には少なくとも 1 要素含まれる
+        \assert($window !== []);
 
         $result[] = $mode === Mode::MODE_ASSOC ? $window : array_values($window);
     }

--- a/src/windowed.php
+++ b/src/windowed.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列上をスライディング窓で走査し、各窓を並べた list を返します。
+ *
+ * 窓の開始位置は 0, $step, 2 * $step, ... と進みます。
+ * $partial が false のときは要素が $size 個そろう完全な窓だけを返し、
+ * true のときは開始位置が要素数未満であれば残りが $size 未満でも窓を作ります（空の窓は作りません）。
+ *
+ * 例:
+ *   windowed([1, 2, 3, 4, 5], 3)                  // [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+ *   windowed([1, 2, 3, 4, 5], 3, 2)               // [[1, 2, 3], [3, 4, 5]]
+ *   windowed([1, 2, 3, 4, 5], 3, 2, true)         // [[1, 2, 3], [3, 4, 5], [5]]
+ *   windowed([1, 2], 3)                           // []
+ *   windowed([1, 2], 3, 1, true)                  // [[1, 2], [2]] （開始位置 1 の窓も作るため 2 個返る）
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param int $size 1 つの窓に含める要素数（1 以上）
+ * @param int $step 窓の開始位置を進める幅（1 以上）
+ * @param bool $partial true のときは末尾の欠けた窓も返す
+ * @param Mode $mode MODE_LIST のときは各窓内を 0 始まりの連番にし、MODE_ASSOC のときは元のキーを保持する。MODE_AUTO のときは入力に応じて判定する
+ * @throws \InvalidArgumentException $size または $step が 1 未満のとき
+ * @return list<list<V>|array<K, V>>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<list<V>> :
+ *     ($mode is Mode::MODE_ASSOC ? list<array<K, V>> :
+ *       ($input is list<V> ? list<list<V>> :
+ *         list<array<K, V>>
+ *  )))
+ */
+function windowed(
+    array $input,
+    int $size,
+    int $step = 1,
+    bool $partial = false,
+    Mode $mode = Mode::MODE_AUTO,
+): array {
+    if ($size <= 0) {
+        throw new \InvalidArgumentException('$size は 1 以上である必要があります。');
+    }
+
+    if ($step <= 0) {
+        throw new \InvalidArgumentException('$step は 1 以上である必要があります。');
+    }
+
+    $mode = Mode::check_mode($mode, $input);
+
+    $count  = \count($input);
+    $result = [];
+
+    for ($offset = 0; $offset < $count; $offset += $step) {
+        if (!$partial && $offset + $size > $count) {
+            break;
+        }
+
+        // キーを保持したまま切り出し、MODE_LIST のときだけ窓の中を連番へ振り直す
+        // （array_slice は $preserve_keys が false でも文字列キーを維持するため）
+        $window = \array_slice($input, $offset, $size, true);
+
+        $result[] = $mode === Mode::MODE_ASSOC ? $window : array_values($window);
+    }
+
+    return $result;
+}

--- a/tests/ChunkTest.php
+++ b/tests/ChunkTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class ChunkTest extends TestCase
+{
+    public function testChunkOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = chunk($input, 3);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testChunkOnDivisibleListSplitsEvenly(): void
+    {
+        $input = [1, 2, 3, 4, 5, 6];
+
+        $result = chunk($input, 2);
+
+        $this->assertSame([[1, 2], [3, 4], [5, 6]], $result);
+    }
+
+    public function testChunkOnIndivisibleListKeepsRemainder(): void
+    {
+        $input = [1, 2, 3, 4, 5];
+
+        $result = chunk($input, 2);
+
+        $this->assertSame([[1, 2], [3, 4], [5]], $result);
+    }
+
+    public function testChunkWithSizeGreaterThanCountReturnsSingleChunk(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = chunk($input, 10);
+
+        $this->assertSame([[1, 2, 3]], $result);
+    }
+
+    public function testChunkWithSizeOneReturnsSingletonChunks(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = chunk($input, 1);
+
+        $this->assertSame([[1], [2], [3]], $result);
+    }
+
+    public function testChunkWithZeroSizeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$size は 1 以上である必要があります。');
+
+        chunk([1, 2, 3], 0);
+    }
+
+    public function testChunkWithNegativeSizeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$size は 1 以上である必要があります。');
+
+        chunk([1, 2, 3], -1);
+    }
+
+    public function testChunkOnAssocInputPreservesKeysInEachChunk(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+        ];
+
+        $result = chunk($input, 2);
+
+        $this->assertSame([
+            ['alice' => 20, 'bob' => 17],
+            ['carol' => 23],
+        ], $result);
+    }
+
+    public function testChunkOnAssocInputWithListModeReindexesEachChunk(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+        ];
+
+        $result = chunk($input, 2, Mode::MODE_LIST);
+
+        $this->assertSame([[20, 17], [23]], $result);
+    }
+
+    public function testChunkOnListInputWithAssocModePreservesIndexes(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = chunk($input, 2, Mode::MODE_ASSOC);
+
+        $this->assertSame([
+            [0 => 1, 1 => 2],
+            [2 => 3],
+        ], $result);
+    }
+
+    public function testChunkDoesNotModifyInput(): void
+    {
+        $input = ['alice' => 20, 'bob' => 17];
+
+        chunk($input, 1, Mode::MODE_LIST);
+
+        $this->assertSame(['alice' => 20, 'bob' => 17], $input);
+    }
+}

--- a/tests/ChunkTest.php
+++ b/tests/ChunkTest.php
@@ -17,6 +17,19 @@ final class ChunkTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    /**
+     * 空配列リテラルを変数に入れず直接渡す呼び出しです。
+     *
+     * 戻り値の assoc 側を non-empty-array<K, V> にすると non-empty-array<never, never> が解決できず、
+     * この形の呼び出しだけが PHPStan で落ちます。その回帰を捕まえるために各モードで呼びます。
+     */
+    public function testChunkOnEmptyArrayLiteralReturnsEmptyInEveryMode(): void
+    {
+        $this->assertSame([], chunk([], 2));
+        $this->assertSame([], chunk([], 2, Mode::MODE_LIST));
+        $this->assertSame([], chunk([], 2, Mode::MODE_ASSOC));
+    }
+
     public function testChunkOnDivisibleListSplitsEvenly(): void
     {
         $input = [1, 2, 3, 4, 5, 6];
@@ -58,7 +71,7 @@ final class ChunkTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$size は 1 以上である必要があります。');
 
-        chunk([1, 2, 3], 0);
+        chunk([1, 2, 3], $this->invalidPositiveInt(0));
     }
 
     public function testChunkWithNegativeSizeThrows(): void
@@ -66,7 +79,7 @@ final class ChunkTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$size は 1 以上である必要があります。');
 
-        chunk([1, 2, 3], -1);
+        chunk([1, 2, 3], $this->invalidPositiveInt(-1));
     }
 
     public function testChunkOnAssocInputPreservesKeysInEachChunk(): void
@@ -117,5 +130,22 @@ final class ChunkTest extends TestCase
         chunk($input, 1, Mode::MODE_LIST);
 
         $this->assertSame(['alice' => 20, 'bob' => 17], $input);
+    }
+
+    /**
+     * 実行時の防御を検証するために不正な $size を作ります。
+     *
+     * chunk は $size に positive-int を宣言しているため 0 や負数を直接渡すと静的解析で弾かれますが、
+     * phpdoc の型は実行時には強制されないので、ライブラリ利用者は不正値を渡せてしまいます。
+     * その状況を再現するため、int を経由して positive-int として扱わせます。
+     *
+     * @return positive-int
+     */
+    private function invalidPositiveInt(int $value): int
+    {
+        /** @var positive-int $widened */
+        $widened = $value;
+
+        return $widened;
     }
 }

--- a/tests/HeadOptionTest.php
+++ b/tests/HeadOptionTest.php
@@ -53,7 +53,6 @@ final class HeadOptionTest extends TestCase
         $input  = [];
         $result = head_option($input);
 
-        // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertNull($result);
     }
 

--- a/tests/LastOptionTest.php
+++ b/tests/LastOptionTest.php
@@ -53,7 +53,6 @@ final class LastOptionTest extends TestCase
         $input  = [];
         $result = last_option($input);
 
-        // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertNull($result);
     }
 

--- a/tests/WindowedTest.php
+++ b/tests/WindowedTest.php
@@ -62,6 +62,19 @@ final class WindowedTest extends TestCase
         $this->assertSame([], windowed($input, 3, 1, true));
     }
 
+    /**
+     * 空配列リテラルを変数に入れず直接渡す呼び出しです。
+     *
+     * 戻り値の assoc 側を non-empty-array<K, V> にすると non-empty-array<never, never> が解決できず、
+     * この形の呼び出しだけが PHPStan で落ちます。その回帰を捕まえるために各モードで呼びます。
+     */
+    public function testWindowedOnEmptyArrayLiteralReturnsEmptyInEveryMode(): void
+    {
+        $this->assertSame([], windowed([], 2));
+        $this->assertSame([], windowed([], 2, 1, false, Mode::MODE_LIST));
+        $this->assertSame([], windowed([], 2, 1, false, Mode::MODE_ASSOC));
+    }
+
     public function testWindowedWithSizeOneReturnsSingletonWindows(): void
     {
         $input = [1, 2, 3];
@@ -95,7 +108,7 @@ final class WindowedTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$size は 1 以上である必要があります。');
 
-        windowed([1, 2, 3], 0);
+        windowed([1, 2, 3], $this->invalidPositiveInt(0));
     }
 
     public function testWindowedWithNegativeSizeThrows(): void
@@ -103,7 +116,7 @@ final class WindowedTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$size は 1 以上である必要があります。');
 
-        windowed([1, 2, 3], -1);
+        windowed([1, 2, 3], $this->invalidPositiveInt(-1));
     }
 
     public function testWindowedWithZeroStepThrows(): void
@@ -111,7 +124,7 @@ final class WindowedTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$step は 1 以上である必要があります。');
 
-        windowed([1, 2, 3], 2, 0);
+        windowed([1, 2, 3], 2, $this->invalidPositiveInt(0));
     }
 
     public function testWindowedWithNegativeStepThrows(): void
@@ -119,7 +132,7 @@ final class WindowedTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$step は 1 以上である必要があります。');
 
-        windowed([1, 2, 3], 2, -1);
+        windowed([1, 2, 3], 2, $this->invalidPositiveInt(-1));
     }
 
     public function testWindowedOnAssocInputPreservesKeysInEachWindow(): void
@@ -170,5 +183,22 @@ final class WindowedTest extends TestCase
         windowed($input, 2, 1, true, Mode::MODE_LIST);
 
         $this->assertSame(['alice' => 20, 'bob' => 17, 'carol' => 23], $input);
+    }
+
+    /**
+     * 実行時の防御を検証するために不正な $size / $step を作ります。
+     *
+     * windowed は $size / $step に positive-int を宣言しているため 0 や負数を直接渡すと静的解析で弾かれますが、
+     * phpdoc の型は実行時には強制されないので、ライブラリ利用者は不正値を渡せてしまいます。
+     * その状況を再現するため、int を経由して positive-int として扱わせます。
+     *
+     * @return positive-int
+     */
+    private function invalidPositiveInt(int $value): int
+    {
+        /** @var positive-int $widened */
+        $widened = $value;
+
+        return $widened;
     }
 }

--- a/tests/WindowedTest.php
+++ b/tests/WindowedTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class WindowedTest extends TestCase
+{
+    public function testWindowedWithDefaultStepReturnsFullWindows(): void
+    {
+        $input = [1, 2, 3, 4, 5];
+
+        $result = windowed($input, 3);
+
+        $this->assertSame([[1, 2, 3], [2, 3, 4], [3, 4, 5]], $result);
+    }
+
+    public function testWindowedWithStepSkipsStartPositions(): void
+    {
+        $input = [1, 2, 3, 4, 5];
+
+        $result = windowed($input, 3, 2);
+
+        $this->assertSame([[1, 2, 3], [3, 4, 5]], $result);
+    }
+
+    public function testWindowedWithPartialReturnsTrailingIncompleteWindow(): void
+    {
+        $input = [1, 2, 3, 4, 5];
+
+        $result = windowed($input, 3, 2, true);
+
+        $this->assertSame([[1, 2, 3], [3, 4, 5], [5]], $result);
+    }
+
+    public function testWindowedWithSizeGreaterThanCountReturnsEmpty(): void
+    {
+        $input = [1, 2];
+
+        $result = windowed($input, 3);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testWindowedWithSizeGreaterThanCountAndPartialReturnsWindowsFromEachStart(): void
+    {
+        $input = [1, 2];
+
+        $result = windowed($input, 3, 1, true);
+
+        // 開始位置が件数未満なら窓を作るため、開始位置 1 の [2] も含まれる（Kotlin の windowed と同じ）
+        $this->assertSame([[1, 2], [2]], $result);
+    }
+
+    public function testWindowedOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $this->assertSame([], windowed($input, 3));
+        $this->assertSame([], windowed($input, 3, 1, true));
+    }
+
+    public function testWindowedWithSizeOneReturnsSingletonWindows(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = windowed($input, 1);
+
+        $this->assertSame([[1], [2], [3]], $result);
+    }
+
+    public function testWindowedWithStepGreaterThanSizeSkipsElements(): void
+    {
+        $input = [1, 2, 3, 4, 5];
+
+        $result = windowed($input, 2, 3);
+
+        $this->assertSame([[1, 2], [4, 5]], $result);
+    }
+
+    public function testWindowedWithPartialWhenLastWindowEndsExactlyDoesNotAppendEmptyWindow(): void
+    {
+        $input = [1, 2, 3, 4];
+
+        $result = windowed($input, 2, 2, true);
+
+        // 開始位置 4 は件数と同じで窓を作らないため、末尾に空の窓は付かない
+        $this->assertSame([[1, 2], [3, 4]], $result);
+    }
+
+    public function testWindowedWithZeroSizeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$size は 1 以上である必要があります。');
+
+        windowed([1, 2, 3], 0);
+    }
+
+    public function testWindowedWithNegativeSizeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$size は 1 以上である必要があります。');
+
+        windowed([1, 2, 3], -1);
+    }
+
+    public function testWindowedWithZeroStepThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$step は 1 以上である必要があります。');
+
+        windowed([1, 2, 3], 2, 0);
+    }
+
+    public function testWindowedWithNegativeStepThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$step は 1 以上である必要があります。');
+
+        windowed([1, 2, 3], 2, -1);
+    }
+
+    public function testWindowedOnAssocInputPreservesKeysInEachWindow(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+        ];
+
+        $result = windowed($input, 2);
+
+        $this->assertSame([
+            ['alice' => 20, 'bob' => 17],
+            ['bob' => 17, 'carol' => 23],
+        ], $result);
+    }
+
+    public function testWindowedOnAssocInputWithListModeReindexesEachWindow(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+        ];
+
+        $result = windowed($input, 2, 1, false, Mode::MODE_LIST);
+
+        $this->assertSame([[20, 17], [17, 23]], $result);
+    }
+
+    public function testWindowedOnListInputWithAssocModePreservesIndexes(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = windowed($input, 2, 1, false, Mode::MODE_ASSOC);
+
+        $this->assertSame([
+            [0 => 1, 1 => 2],
+            [1 => 2, 2 => 3],
+        ], $result);
+    }
+
+    public function testWindowedDoesNotModifyInput(): void
+    {
+        $input = ['alice' => 20, 'bob' => 17, 'carol' => 23];
+
+        windowed($input, 2, 1, true, Mode::MODE_LIST);
+
+        $this->assertSame(['alice' => 20, 'bob' => 17, 'carol' => 23], $input);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
固定サイズで分割する `chunk` と、スライディング窓を作る `windowed` を追加します。

## 変更点
- `src/chunk.php` — `array_chunk` 相当 + mode 対応。`size <= 0` は `InvalidArgumentException`
- `src/windowed.php` — 開始位置を step 刻みで進める。`partial` で末尾の欠けた窓を含めるか選ぶ
- `tests/ChunkTest.php` (11 ケース) / `tests/WindowedTest.php` (16 ケース)
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：
    - `windowed([1,2,3,4,5], 3)` → `[[1,2,3], [2,3,4], [3,4,5]]`
    - `windowed([1,2,3,4,5], 3, 2, true)` → `[[1,2,3], [3,4,5], [5]]`
    - `chunk([1,2,3,4,5], 2)` → `[[1,2], [3,4], [5]]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (125 tests, 137 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）

### `windowed` の窓生成規則

Kotlin の `windowed(size, step, partialWindows)` に合わせました。開始位置は 0, step, 2*step, ... と進み、`partial = true` のときは**開始位置が件数未満であれば残りが size 未満でも窓を作ります** (空の窓は作りません)。

```
windowed([1, 2], 3, 1, true)  // [[1, 2], [2]]  ← 開始位置 1 の窓も作るので 2 個
```

直感に反しやすいので phpdoc に例を置き、テストでも固定しています。

### `array_slice` の落とし穴

`array_slice()` は `$preserve_keys = false` でも**文字列キーを保持します** (再付番されるのは数値キーだけ)。そのため `windowed` は `array_slice(..., true)` で切り出してから `MODE_LIST` のときだけ `array_values()` する実装にしています。`chunk` が使う `array_chunk()` にはこの問題がないので委譲のままです。

なお既存の `src/slice.php` はこの対処がなく、`slice(['a'=>1,'b'=>2], 0, 2, Mode::MODE_LIST)` が `['a'=>1,'b'=>2]` を返して宣言している `list<V>` に反します。既存関数の変更はこの PR のスコープ外なので触っていませんが、別 issue に切り出す価値があります。

### その他

- 例外を投げる関数はこの 2 つがリポジトリで初なので、メッセージ文言 (`$size は 1 以上である必要があります。`) が先例になります。文体を揃えたい場合は指摘してください
- `chunk_by` (隣接要素をキーの変化で切る関数) は #75 で別途追加しています。用途が異なります
- `@phpstan-param` の条件型は付けていません (「assoc 入力 + `MODE_LIST`」が型エラーになるため。`slice.php` / `map.php` / `unique.php` と同じ形)

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追記: 整数レンジ型を入れました (2 コミット追加)

オーナーの方針 (`positive-int` / `non-negative-int` を積極的に使う。特に `$size` を比較するような場合) を反映しました。

### `ci: PHPStan の treatPhpDocTypesAsCertain を無効にする`

`@param positive-int $size` と実行時の `if ($size <= 0) throw` は **level 10 の既定では共存できません**。

```
Comparison operation "<=" between int<1, max> and 0 is always false.
🪪 smallerOrEqual.alwaysFalse
💡 ... you can turn off this check by setting treatPhpDocTypesAsCertain: false
```

phpdoc の型は実行時に強制されないので、ライブラリとしては型宣言と実行時の防御を両立させたいところです。特に `windowed` の `$step <= 0` を消すと `$offset` が進まず**無限ループ**します (`$size <= 0` の方は空の窓が並ぶ静かな失敗)。

`treatPhpDocTypesAsCertain: false` を入れた副作用は実測しました。**既存の `@phpstan-ignore` 2 箇所が無効になるだけ**で (`HeadOptionTest` / `LastOptionTest` の `method.alreadyNarrowedType`)、同じコミットで削除しています。native type 由来の常真/常偽検出は残るので、`src/reduce.php` と `tests/AnyTest.php` の ignore は有効なまま残しました。設定変更の前後で PHPStan のエラーは 0 → 0 です。

### `refactor: chunk と windowed に整数レンジ型を入れる`

- `chunk`: `@param positive-int $size`
- `windowed`: `@param positive-int $size` / `@param positive-int $step`
- 戻り値の **list 側**を `non-empty-list<V>` に絞る (空のチャンク・窓は作らないため)
- **assoc 側は `non-empty` を付けていません** — `non-empty-array<never, never>` が unresolvable になり、`chunk([], 2)` のような空配列リテラルの呼び出しを壊すためです (実測で確認し、回帰テストを追加しました)
- 実行時の例外チェックと日本語メッセージの固定は維持

`windowed` に `\assert($window !== []);` を 1 行入れています。`array_slice()` の戻り値は `array<K, V>` なので `non-empty-list<V>` に絞ると `return.type` で落ちるためで、ループ不変条件 (`$offset < $count` かつ `$size >= 1`) の表明も兼ねています。到達しない `if` 分岐を作るより素直だと判断しましたが、リポジトリの好みに合わなければ言ってください。

異常系テスト (`$size = 0` / `-1`、`$step = 0` / `-1`) は `positive-int` 宣言後もそのままでは通らないので、`int` を一段挟んで widening する private ヘルパー経由にしました。**テストは 1 件も削っていません** (理由はヘルパーの docblock に記載)。

追加コミットのフッターは `Refs #70, #71` にしてあります (型注釈に対応する issue が無いため、`Closes` は既存 2 コミットのぶんだけです)。
