### PR TITLE
feat: all と none を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/all.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/all.php"
+            "src/all.php",
+            "src/none.php"
         ]
     },
     "autoload-dev": {

--- a/src/all.php
+++ b/src/all.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 全ての要素がコールバック関数を満たすかどうかを調べる (空配列は vacuous truth により true を返す)
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): bool $callback フィルターする条件
+ */
+function all(array $input, callable $callback): bool
+{
+    return array_all($input, $callback);
+}

--- a/src/none.php
+++ b/src/none.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 条件を満たす要素が一つもないかどうかを調べる (空配列は vacuous truth により true を返す)
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): bool $callback フィルターする条件
+ */
+function none(array $input, callable $callback): bool
+{
+    return !any($input, $callback);
+}

--- a/tests/AllTest.php
+++ b/tests/AllTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class AllTest extends TestCase
+{
+    public function testAllOnEmptyArrayReturnsTrueAndDoesNotCallCallback(): void
+    {
+        $input     = [];
+        $callCount = 0;
+
+        $result = all($input, function () use (&$callCount): bool {
+            $callCount++;
+
+            return true;
+        });
+
+        $this->assertTrue($result);
+        $this->assertSame(0, $callCount);
+    }
+
+    public function testAllReturnsTrueWhenAllElementsMatch(): void
+    {
+        // @phpstan-ignore identical.alwaysTrue
+        $this->assertTrue(all([2, 4, 6, 8], fn (int $v): bool => $v % 2 === 0));
+    }
+
+    public function testAllReturnsFalseWhenNoElementMatches(): void
+    {
+        // @phpstan-ignore identical.alwaysFalse
+        $this->assertFalse(all([1, 3, 5], fn (int $v): bool => $v % 2 === 0));
+    }
+
+    public function testAllReturnsFalseWithMixedElements(): void
+    {
+        $this->assertFalse(all([2, 4, 5, 6], fn (int $v): bool => $v % 2 === 0));
+    }
+
+    public function testAllWorksWithListInputAndUsesIntKey(): void
+    {
+        $input = [10, 20, 30];
+
+        $result = all($input, fn (int $v, int $k): bool => $v === ($k + 1) * 10);
+
+        $this->assertTrue($result);
+    }
+
+    public function testAllWorksWithAssocArrayAndUsesStringKey(): void
+    {
+        $input = ['a' => 1, 'b' => 2, 'c' => 3];
+
+        $result = all($input, function (int $v, string $k): bool {
+            return match ($k) {
+                'a'     => $v === 1,
+                'b'     => $v === 2,
+                default => $v === 3,
+            };
+        });
+
+        $this->assertTrue($result);
+    }
+
+    public function testAllShortCircuitsOnFirstFalse(): void
+    {
+        $input     = [1, 2, 3, 4];
+        $callCount = 0;
+
+        $result = all($input, function (int $v, int $k) use (&$callCount): bool {
+            $callCount++;
+
+            return $v !== 2;
+        });
+
+        $this->assertFalse($result);
+        $this->assertSame(2, $callCount);
+    }
+}

--- a/tests/NoneTest.php
+++ b/tests/NoneTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class NoneTest extends TestCase
+{
+    public function testNoneOnEmptyArrayReturnsTrueAndDoesNotCallCallback(): void
+    {
+        $input     = [];
+        $callCount = 0;
+
+        $result = none($input, function () use (&$callCount): bool {
+            $callCount++;
+
+            return true;
+        });
+
+        $this->assertTrue($result);
+        $this->assertSame(0, $callCount);
+    }
+
+    public function testNoneReturnsTrueWhenNoElementMatches(): void
+    {
+        // @phpstan-ignore identical.alwaysFalse
+        $this->assertTrue(none([1, 3, 5], fn (int $v): bool => $v % 2 === 0));
+    }
+
+    public function testNoneReturnsFalseWhenAllElementsMatch(): void
+    {
+        // @phpstan-ignore identical.alwaysTrue
+        $this->assertFalse(none([2, 4, 6], fn (int $v): bool => $v % 2 === 0));
+    }
+
+    public function testNoneReturnsFalseWithMixedElements(): void
+    {
+        $this->assertFalse(none([1, 2, 3], fn (int $v): bool => $v % 2 === 0));
+    }
+
+    public function testNoneWorksWithListInputAndUsesIntKey(): void
+    {
+        $input = [10, 20, 30];
+
+        $result = none($input, fn (int $v, int $k): bool => $v !== ($k + 1) * 10);
+
+        $this->assertTrue($result);
+    }
+
+    public function testNoneWorksWithAssocArrayAndUsesStringKey(): void
+    {
+        $input = ['a' => 1, 'b' => 2, 'c' => 3];
+
+        $result = none($input, function (int $v, string $k): bool {
+            return match ($k) {
+                'a'     => $v !== 1,
+                'b'     => $v !== 2,
+                default => $v !== 3,
+            };
+        });
+
+        $this->assertTrue($result);
+    }
+
+    public function testNoneShortCircuitsOnFirstTrue(): void
+    {
+        $input     = [1, 2, 3, 4];
+        $callCount = 0;
+
+        $result = none($input, function (int $v, int $k) use (&$callCount): bool {
+            $callCount++;
+
+            return $v === 2;
+        });
+
+        $this->assertFalse($result);
+        $this->assertSame(2, $callCount);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
既存の `any` と対になる `all` (全件成立) と `none` (1 件も成立しない) を追加します。

## 変更点
- `src/all.php` — PHP 8.4 の `array_all()` に委譲。空配列は vacuous truth で `true`
- `src/none.php` — `!any($input, $callback)`。空配列は `true`
- `tests/AllTest.php` / `tests/NoneTest.php` — 各 7 ケース
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：`all([], fn () => false)` → `true` / `none([1, 2], fn ($v) => $v > 5)` → `true`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (111 tests, 120 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）
- 引数名は `any` に揃えて `$callback` にしました (`filter` / `collect` / `chunk_by` も同じ)
- `none` は `any` の否定なので 1 行委譲にして、`any` / `all` / `none` の 3 関数を同じ層に並べました。短絡の保証も `array_any()` / `array_all()` の 1 箇所に集約されます
- 短絡評価は、呼び出し回数を数えるクロージャで「判定確定後に呼ばれない」ことを assert しています。空配列で一度も呼ばれないことも同様
- キーが述語に渡ることは、キーを `match` の分岐に使う形で実質的に検証しています

Closes #61
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
