### PR TITLE
feat: count_by と associate を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/count_by.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/count_by.php"
+            "src/count_by.php",
+            "src/associate.php"
         ]
     },
     "autoload-dev": {

--- a/src/associate.php
+++ b/src/associate.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * コールバックが返す [キー, 値] のペアから新しい連想配列を構築します。
+ *
+ * @template K of array-key
+ * @template V
+ * @template G of array-key
+ * @template E
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): array{0: G, 1: E} $transform 新しいキーと値のペアを返す関数（第1引数: 値, 第2引数: キー）
+ * @return array<G, E> 元のキーは捨てられ、$transform が返したキーだけが使われる。同一キーが衝突した場合は後勝ちになる
+ */
+function associate(array $input, callable $transform): array
+{
+    $result = [];
+
+    foreach ($input as $key => $value) {
+        [$newKey, $newValue] = $transform($value, $key);
+
+        $result[$newKey] = $newValue;
+    }
+
+    return $result;
+}

--- a/src/count_by.php
+++ b/src/count_by.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * コールバックが返す分類キーごとに要素の件数を集計します。
+ *
+ * @template K of array-key
+ * @template V
+ * @template G of array-key
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): G $classifier 分類キーを返す関数（第1引数: 値, 第2引数: キー）
+ * @return array<G, positive-int> 分類キーごとの件数。キーの出現順は初出順を維持する
+ */
+function count_by(array $input, callable $classifier): array
+{
+    $result = [];
+
+    foreach ($input as $key => $value) {
+        $groupKey = $classifier($value, $key);
+
+        $result[$groupKey] = ($result[$groupKey] ?? 0) + 1;
+    }
+
+    return $result;
+}

--- a/tests/AssociateTest.php
+++ b/tests/AssociateTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class AssociateTest extends TestCase
+{
+    public function testAssociateOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = associate(
+            $input,
+            fn ($value, $index): array => [$index, $value],
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testAssociateOnListInput(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = associate(
+            $input,
+            fn (int $value, int $index): array => ['key' . $value, $value * 10],
+        );
+
+        $this->assertSame([
+            'key1' => 10,
+            'key2' => 20,
+            'key3' => 30,
+        ], $result);
+    }
+
+    public function testAssociateOnAssocInputDiscardsOriginalKeys(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        $result = associate(
+            $input,
+            fn (int $age, string $name): array => [$name . '_key', $age],
+        );
+
+        $this->assertSame([
+            'alice_key' => 20,
+            'bob_key'   => 17,
+        ], $result);
+    }
+
+    public function testAssociateOnKeyCollisionKeepsLastValue(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = associate(
+            $input,
+            fn (int $value): array => ['same', $value],
+        );
+
+        $this->assertSame([
+            'same' => 3,
+        ], $result);
+    }
+
+    public function testAssociateWithIntegerKeys(): void
+    {
+        $input = ['x', 'y', 'z'];
+
+        $result = associate(
+            $input,
+            fn (string $value, int $index): array => [$index * 2, $value],
+        );
+
+        $this->assertSame([
+            0 => 'x',
+            2 => 'y',
+            4 => 'z',
+        ], $result);
+    }
+
+    public function testAssociateAllowsNullValue(): void
+    {
+        $input = ['a', 'b'];
+
+        $result = associate(
+            $input,
+            fn (string $value): array => [$value, null],
+        );
+
+        $this->assertSame([
+            'a' => null,
+            'b' => null,
+        ], $result);
+    }
+
+    public function testAssociateDoesNotMutateInput(): void
+    {
+        $input = [1, 2, 3];
+
+        associate(
+            $input,
+            fn (int $value): array => ['key' . $value, $value],
+        );
+
+        $this->assertSame([1, 2, 3], $input);
+    }
+}

--- a/tests/CountByTest.php
+++ b/tests/CountByTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class CountByTest extends TestCase
+{
+    public function testCountByOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = count_by(
+            $input,
+            fn ($value, $index): string => 'all',
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testCountByWithSingleKey(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = count_by(
+            $input,
+            fn (int $value, int $index): string => 'all',
+        );
+
+        $this->assertSame(['all' => 3], $result);
+    }
+
+    public function testCountByWithMultipleKeysMixed(): void
+    {
+        $input = [3, 1, 4, 2, 5, 6];
+
+        $result = count_by(
+            $input,
+            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+        );
+
+        $this->assertSame([
+            'odd'  => 3,
+            'even' => 3,
+        ], $result);
+    }
+
+    public function testCountByKeepsFirstAppearanceOrder(): void
+    {
+        $input = ['b', 'a', 'b', 'c', 'a'];
+
+        $result = count_by(
+            $input,
+            fn (string $value): string => $value,
+        );
+
+        $this->assertSame([
+            'b' => 2,
+            'a' => 2,
+            'c' => 1,
+        ], $result);
+        $this->assertSame(['b', 'a', 'c'], array_keys($result));
+    }
+
+    public function testCountByWithIntegerClassificationKeys(): void
+    {
+        $input = [10, 25, 30, 42];
+
+        $result = count_by(
+            $input,
+            fn (int $v): int => intdiv($v, 10),
+        );
+
+        $this->assertSame([
+            1 => 1,
+            2 => 1,
+            3 => 1,
+            4 => 1,
+        ], $result);
+    }
+
+    public function testCountByOnAssocInputReceivesKeys(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = count_by(
+            $input,
+            fn (int $age, string $name): string => $name[0],
+        );
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 1,
+            'c' => 1,
+            'd' => 1,
+        ], $result);
+    }
+
+    public function testCountByDoesNotMutateInput(): void
+    {
+        $input = [1, 2, 3];
+
+        count_by(
+            $input,
+            fn (int $value): string => $value % 2 === 0 ? 'even' : 'odd',
+        );
+
+        $this->assertSame([1, 2, 3], $input);
+    }
+
+    public function testCountByResultValuesArePositiveInt(): void
+    {
+        $input = [1, 2, 3, 4];
+
+        $result = count_by(
+            $input,
+            fn (int $value): string => $value % 2 === 0 ? 'even' : 'odd',
+        );
+
+        $this->requiresPositiveIntValues($result);
+
+        $this->assertSame(['odd' => 2, 'even' => 2], $result);
+    }
+
+    /**
+     * @param array<array-key, positive-int> $counts
+     */
+    private function requiresPositiveIntValues(array $counts): void
+    {
+        foreach ($counts as $count) {
+            $this->assertGreaterThan(0, $count);
+        }
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
分類キーごとの件数を数える `count_by` と、`[キー, 値]` のペアから連想配列を組み立てる `associate` を追加します。

## 変更点
- `src/count_by.php` — `group_by` + `count` を 1 パスで。キーの出現順は初出順を維持
- `src/associate.php` — callback が返した `array{0: キー, 1: 値}` から assoc を構築。衝突は後勝ち
- `tests/CountByTest.php` / `tests/AssociateTest.php`
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：`count_by([1, 2, 3, 4], fn ($v) => $v % 2 === 0 ? 'even' : 'odd')` → `['odd' => 2, 'even' => 2]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (111 tests, 117 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）
- どちらも戻り値が常に assoc なので `Mode` は取りません
- `$classifier` / `$transform` の引数名は `group_by` の `$classifier` に揃えています
- `associate` は元のキーを捨てて callback が返したキーだけを使います。同一キーの衝突は後勝ち (phpdoc に明記、テストで担保)
- `count_by` は 1 件も該当しないキーを結果に含めないので、値は常に 1 以上です
- `associate_by` / `associate_with` (キーだけ・値だけ指定する簡易版) は入れていません

Closes #63
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追記: `count_by` の戻り値を `positive-int` にしました

phpdoc に「1 件も該当しないキーは含まれず、値は常に 1 以上」と散文で書いていたのを、型で表現しました。

```php
@return array<G, positive-int>
```

散文側の重複説明は削っています。`positive-int` が効いていることを示すため、`@param array<array-key, positive-int> $counts` を取る private ヘルパーに結果を渡すテストを 1 件追加しました。

`assertSame(['odd' => 2, 'even' => 2], $result)` のようなリテラル比較で `alreadyNarrowedType` が出ないかを確認しましたが、level 10 で問題ありませんでした。

なお **`Mode` は追加していません**。`count_by` / `associate` は戻り値のキーが入力のキーと無関係 (分類キー / callback が返したキー) なので、`Mode` で変わるものが無いためです。

`OK (119 tests, 127 assertions)` / PHPStan level 10 `[OK] No errors`。
