### PR TITLE
feat: take と drop を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/take.php"
+            "src/take.php",
+            "src/drop.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/take.php"
         ]
     },
     "autoload-dev": {

--- a/src/drop.php
+++ b/src/drop.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列の先頭から $n 件を除外します。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param int $n 除外する件数（0 以下ならすべて、件数以上なら空配列）
+ * @return list<V>|array<K, V>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V> :
+ *       ($input is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function drop(array $input, int $n, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = \array_slice($input, max($n, 0), null, true);
+
+    return $mode === Mode::MODE_LIST ? array_values($result) : $result;
+}

--- a/src/take.php
+++ b/src/take.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列の先頭から最大 $n 件を取り出します。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param int $n 取り出す件数（0 以下なら空配列、件数以上ならすべて）
+ * @return list<V>|array<K, V>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V> :
+ *       ($input is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function take(array $input, int $n, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = \array_slice($input, 0, max($n, 0), true);
+
+    return $mode === Mode::MODE_LIST ? array_values($result) : $result;
+}

--- a/tests/DropTest.php
+++ b/tests/DropTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class DropTest extends TestCase
+{
+    public function testDropOnEmptyArrayReturnsEmpty(): void
+    {
+        $result = drop([], 2);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDropWithZeroNReturnsAll(): void
+    {
+        $result = drop([1, 2, 3], 0);
+
+        $this->assertSame([1, 2, 3], $result);
+    }
+
+    public function testDropWithNegativeNReturnsAll(): void
+    {
+        $result = drop([1, 2, 3], -1);
+
+        $this->assertSame([1, 2, 3], $result);
+    }
+
+    public function testDropWithNLessThanCountReturnsPartial(): void
+    {
+        $result = drop([1, 2, 3, 4], 2);
+
+        $this->assertSame([3, 4], $result);
+    }
+
+    public function testDropWithNEqualToCountReturnsEmpty(): void
+    {
+        $result = drop([1, 2, 3], 3);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDropWithNGreaterThanCountReturnsEmpty(): void
+    {
+        $result = drop([1, 2, 3], 10);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDropOnAssocInputPreservesKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+
+        $result = drop($input, 1);
+
+        $this->assertSame([
+            'b' => 2,
+            'c' => 3,
+        ], $result);
+    }
+
+    public function testDropOnAssocInputWithModeListReindexesRemainingKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+
+        $result = drop($input, 1, Mode::MODE_LIST);
+
+        $this->assertSame([2, 3], $result);
+    }
+
+    public function testDropOnListInputWithModeAssocKeepsOriginalIntegerKeys(): void
+    {
+        $result = drop([1, 2, 3], 1, Mode::MODE_ASSOC);
+
+        $this->assertSame([
+            1 => 2,
+            2 => 3,
+        ], $result);
+    }
+
+    public function testDropDoesNotMutateInput(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+            'd' => 4,
+        ];
+
+        drop($input, 2);
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+            'd' => 4,
+        ], $input);
+    }
+}

--- a/tests/TakeTest.php
+++ b/tests/TakeTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class TakeTest extends TestCase
+{
+    public function testTakeOnEmptyArrayReturnsEmpty(): void
+    {
+        $result = take([], 2);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testTakeWithZeroNReturnsEmpty(): void
+    {
+        $result = take([1, 2, 3], 0);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testTakeWithNegativeNReturnsEmpty(): void
+    {
+        $result = take([1, 2, 3], -1);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testTakeWithNLessThanCountReturnsPartial(): void
+    {
+        $result = take([1, 2, 3, 4], 2);
+
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testTakeWithNEqualToCountReturnsAll(): void
+    {
+        $result = take([1, 2, 3], 3);
+
+        $this->assertSame([1, 2, 3], $result);
+    }
+
+    public function testTakeWithNGreaterThanCountReturnsAll(): void
+    {
+        $result = take([1, 2, 3], 10);
+
+        $this->assertSame([1, 2, 3], $result);
+    }
+
+    public function testTakeOnAssocInputPreservesKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+
+        $result = take($input, 2);
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+        ], $result);
+    }
+
+    public function testTakeOnAssocInputWithModeListReindexesKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+
+        $result = take($input, 2, Mode::MODE_LIST);
+
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testTakeOnListInputWithModeAssocPreservesOriginalKeys(): void
+    {
+        $result = take([1, 2, 3], 2, Mode::MODE_ASSOC);
+
+        $this->assertSame([
+            0 => 1,
+            1 => 2,
+        ], $result);
+    }
+
+    public function testTakeDoesNotMutateInput(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+            'd' => 4,
+        ];
+
+        take($input, 2);
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+            'd' => 4,
+        ], $input);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
先頭 n 件を取り出す `take` と、先頭 n 件を捨てる `drop` を追加します。
親 issue #56 の breakdown で挙がっていた基本操作で、`slice` のオフセット計算を毎回書かずに済みます。

## 変更点
- `src/take.php` — 先頭から最大 n 件。`n <= 0` は空、`n >= count` は全件
- `src/drop.php` — 先頭 n 件を除外。`n <= 0` は全件、`n >= count` は空
- `tests/TakeTest.php` / `tests/DropTest.php`
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：
    - `take(['a' => 1, 'b' => 2, 'c' => 3], 2, Mode::MODE_LIST)` → `[1, 2]`
    - `drop([1, 2, 3], 1, Mode::MODE_ASSOC)` → `[1 => 2, 2 => 3]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (117 tests, 122 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）

### `array_slice` の `$preserve_keys` に丸投げしていません

`array_slice()` は `$preserve_keys = false` でも**文字列キーを保持します** (再付番されるのは数値キーだけ)。そのため `array_slice(..., true)` で取り出してから `MODE_LIST` のときだけ `array_values()` する実装にしています。

既存の `src/slice.php` はこの対処がなく、`slice(['a' => 1, 'b' => 2], 0, 2, Mode::MODE_LIST)` が `['a' => 1, 'b' => 2]` を返して宣言している `list<V>` に反します (`tests/SliceTest.php` に assoc 入力 + `MODE_LIST` のケースが無いため露見していません)。既存関数の変更はこの PR のスコープ外なので触っていませんが、別 issue に切り出す価値があります。

### その他

- `@phpstan-param` の条件型は付けていません。付けると「assoc 入力 + `MODE_LIST`」が型エラーになるためで、`src/slice.php` / `src/map.php` / `src/intersect.php` と同じ形です
- list 入力 + `MODE_ASSOC` で整数キーが 0 始まりに詰め直されないこともテストで固定しています

Closes #64
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
