### PR TITLE
feat: take_while と drop_while を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/take_while.php"
+            "src/take_while.php",
+            "src/drop_while.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/take_while.php"
         ]
     },
     "autoload-dev": {

--- a/src/drop_while.php
+++ b/src/drop_while.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列の先頭から $callback が真である間の要素を捨て、初めて偽になった要素以降をすべて返します。
+ *
+ * 境界が確定した後の要素は $callback の結果に関わらずすべて残します。
+ * 境界より後ろで $callback が再び真になっても取り除かない点が filter() と異なります。
+ * 境界確定後は $callback を呼びません。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): bool $callback 除外条件（第1引数: 値, 第2引数: キー）
+ * @return list<V>|array<K, V>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V>:
+ *       ($input is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function drop_while(array $input, callable $callback, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result   = [];
+    $dropping = true;
+
+    foreach ($input as $key => $value) {
+        if ($dropping) {
+            if ($callback($value, $key)) {
+                continue;
+            }
+
+            $dropping = false;
+        }
+
+        if ($mode === Mode::MODE_LIST) {
+            $result[] = $value;
+        } else {
+            $result[$key] = $value;
+        }
+    }
+
+    return $result;
+}

--- a/src/take_while.php
+++ b/src/take_while.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列の先頭から $callback が真である間の要素を取り出します。
+ *
+ * 先頭から評価し、初めて $callback が偽になった時点で境界を確定して評価を打ち切ります
+ * (それ以降の要素には $callback を呼びません)。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): bool $callback 継続条件（第1引数: 値, 第2引数: キー）
+ * @return list<V>|array<K, V>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<V> :
+ *     ($mode is Mode::MODE_ASSOC ? array<K, V>:
+ *       ($input is list<V> ? list<V> :
+ *         array<K, V>
+ *  )))
+ */
+function take_while(array $input, callable $callback, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = [];
+
+    foreach ($input as $key => $value) {
+        if (!$callback($value, $key)) {
+            break;
+        }
+
+        if ($mode === Mode::MODE_LIST) {
+            $result[] = $value;
+        } else {
+            $result[$key] = $value;
+        }
+    }
+
+    return $result;
+}

--- a/tests/DropWhileTest.php
+++ b/tests/DropWhileTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class DropWhileTest extends TestCase
+{
+    public function testDropWhileOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = drop_while(
+            $input,
+            fn ($value, $key): bool => true,
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDropWhileWhenAllElementsSatisfyPredicateReturnsEmpty(): void
+    {
+        /** @var list<int> $input */
+        $input = [1, 2, 3, 4];
+
+        $result = drop_while(
+            $input,
+            fn (int $v): bool => $v < 10,
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testDropWhileWhenFirstElementFailsReturnsAll(): void
+    {
+        $input = [5, 1, 2, 3];
+
+        $result = drop_while(
+            $input,
+            fn (int $v): bool => $v < 3,
+        );
+
+        $this->assertSame([5, 1, 2, 3], $result);
+    }
+
+    public function testDropWhileDropsUntilFirstFailingElement(): void
+    {
+        $input = [1, 2, 5, 6, 1];
+
+        $result = drop_while(
+            $input,
+            fn (int $v): bool => $v < 5,
+        );
+
+        $this->assertSame([5, 6, 1], $result);
+    }
+
+    public function testDropWhileDiffersFromFilterWhenConditionIsSatisfiedAgainAfterBoundary(): void
+    {
+        $input     = [1, 2, 5, 1, 2];
+        $predicate = fn (int $v): bool => $v < 3;
+
+        $dropWhileResult = drop_while($input, $predicate);
+        $filterResult    = filter($input, fn (int $v): bool => !$predicate($v));
+
+        $this->assertSame([5, 1, 2], $dropWhileResult);
+        $this->assertSame([5], $filterResult);
+        $this->assertNotSame($filterResult, $dropWhileResult);
+    }
+
+    public function testDropWhileOnAssocInputPreservesKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 5,
+            'd' => 1,
+        ];
+
+        $result = drop_while(
+            $input,
+            fn (int $v): bool => $v < 3,
+        );
+
+        $this->assertSame(['c' => 5, 'd' => 1], $result);
+    }
+
+    public function testDropWhileOnAssocInputWithListModeReindexes(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 5,
+            'd' => 6,
+        ];
+
+        $result = drop_while(
+            $input,
+            fn (int $v): bool => $v < 3,
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([5, 6], $result);
+    }
+
+    public function testDropWhilePassesCorrectKeyToPredicate(): void
+    {
+        $input = [
+            'x' => 10,
+            'y' => 20,
+            'z' => 30,
+        ];
+        $seenKeys = [];
+
+        drop_while(
+            $input,
+            function (int $value, string $key) use (&$seenKeys): bool {
+                $seenKeys[] = $key;
+
+                return $value < 30;
+            },
+        );
+
+        $this->assertSame(['x', 'y', 'z'], $seenKeys);
+    }
+
+    public function testDropWhileDoesNotMutateInputArray(): void
+    {
+        $input    = [1, 2, 3];
+        $original = $input;
+
+        drop_while(
+            $input,
+            fn (int $v): bool => $v < 2,
+        );
+
+        $this->assertSame($original, $input);
+    }
+
+    public function testDropWhileStopsCallingPredicateAfterBoundaryIsDetermined(): void
+    {
+        $input     = [10, 20, 3, 40, 50];
+        $callCount = 0;
+
+        $result = drop_while(
+            $input,
+            function (int $v) use (&$callCount): bool {
+                ++$callCount;
+
+                return $v > 5;
+            },
+        );
+
+        $this->assertSame(3, $callCount);
+        $this->assertSame([3, 40, 50], $result);
+    }
+
+    public function testDropWhileOnListInputWithAssocModePreservesOriginalIntegerKeys(): void
+    {
+        $input = [1, 2, 5, 6, 1];
+
+        $result = drop_while(
+            $input,
+            fn (int $v): bool => $v < 5,
+            Mode::MODE_ASSOC,
+        );
+
+        $this->assertSame([2 => 5, 3 => 6, 4 => 1], $result);
+    }
+}

--- a/tests/TakeWhileTest.php
+++ b/tests/TakeWhileTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class TakeWhileTest extends TestCase
+{
+    public function testTakeWhileOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = take_while(
+            $input,
+            fn ($value, $key): bool => true,
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testTakeWhileWhenAllElementsSatisfyPredicateReturnsAll(): void
+    {
+        /** @var list<int> $input */
+        $input = [1, 2, 3, 4];
+
+        $result = take_while(
+            $input,
+            fn (int $v): bool => $v < 10,
+        );
+
+        $this->assertSame([1, 2, 3, 4], $result);
+    }
+
+    public function testTakeWhileWhenFirstElementFailsReturnsEmpty(): void
+    {
+        $input = [5, 1, 2, 3];
+
+        $result = take_while(
+            $input,
+            fn (int $v): bool => $v < 3,
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testTakeWhileStopsAtFirstFailingElement(): void
+    {
+        $input = [1, 2, 5, 6, 1];
+
+        $result = take_while(
+            $input,
+            fn (int $v): bool => $v < 5,
+        );
+
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testTakeWhileDiffersFromFilterWhenConditionIsSatisfiedAgainAfterBoundary(): void
+    {
+        $input     = [1, 2, 5, 1, 2];
+        $predicate = fn (int $v): bool => $v < 3;
+
+        $takeWhileResult = take_while($input, $predicate);
+        $filterResult    = filter($input, $predicate);
+
+        $this->assertSame([1, 2], $takeWhileResult);
+        $this->assertSame([1, 2, 1, 2], $filterResult);
+        $this->assertNotSame($filterResult, $takeWhileResult);
+    }
+
+    public function testTakeWhileOnAssocInputPreservesKeys(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 5,
+            'd' => 1,
+        ];
+
+        $result = take_while(
+            $input,
+            fn (int $v): bool => $v < 3,
+        );
+
+        $this->assertSame(['a' => 1, 'b' => 2], $result);
+    }
+
+    public function testTakeWhileOnAssocInputWithListModeReindexes(): void
+    {
+        $input = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 5,
+        ];
+
+        $result = take_while(
+            $input,
+            fn (int $v): bool => $v < 3,
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([1, 2], $result);
+    }
+
+    public function testTakeWhilePassesCorrectKeyToPredicate(): void
+    {
+        $input = [
+            'x' => 10,
+            'y' => 20,
+            'z' => 30,
+        ];
+        $seenKeys = [];
+
+        take_while(
+            $input,
+            function (int $value, string $key) use (&$seenKeys): bool {
+                $seenKeys[] = $key;
+
+                return true;
+            },
+        );
+
+        $this->assertSame(['x', 'y', 'z'], $seenKeys);
+    }
+
+    public function testTakeWhileDoesNotMutateInputArray(): void
+    {
+        $input    = [1, 2, 3];
+        $original = $input;
+
+        take_while(
+            $input,
+            fn (int $v): bool => $v < 2,
+        );
+
+        $this->assertSame($original, $input);
+    }
+
+    public function testTakeWhileStopsCallingPredicateAfterBoundaryIsDetermined(): void
+    {
+        $input     = [10, 20, 3, 40, 50];
+        $callCount = 0;
+
+        $result = take_while(
+            $input,
+            function (int $v) use (&$callCount): bool {
+                ++$callCount;
+
+                return $v > 5;
+            },
+        );
+
+        $this->assertSame(3, $callCount);
+        $this->assertSame([10, 20], $result);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
先頭から条件が続く間だけ取る `take_while` と、その境界までを捨てる `drop_while` を追加します。
`filter` と違い「境界で打ち切る」ので、ソート済み配列の切り出しなどが 1 呼び出しで書けます。

## 変更点
- `src/take_while.php` — 初回 false で境界確定。以降は callback を呼ばない
- `src/drop_while.php` — 境界より後ろは callback が再び true になっても残す
- `tests/TakeWhileTest.php` / `tests/DropWhileTest.php`
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：`drop_while([1, 2, 5, 1, 2], fn ($v) => $v < 3)` → `[5, 1, 2]` (`filter` なら `[1, 2, 1, 2]`)
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (118 tests, 129 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）
- `filter` との違い (境界より後ろは条件を満たさなくても残す) を phpdoc に明記し、`[1, 2, 5, 1, 2]` で両者の結果が異なることをテストで固定しています
- 境界確定後に callback が呼ばれないことは、呼び出し回数を数えるクロージャで assert しています。同じテストで戻り値も見ているので「呼ばれない」と「残る」が 1 ケースで結びついています
- 引数名は既存の `filter` / `any` に揃えて `$callback` にしました
- `@phpstan-param` の条件型は付けていません (「assoc 入力 + `MODE_LIST`」が型エラーになるため。`slice.php` / `map.php` / `intersect.php` と同じ形)
- テスト 2 箇所の `/** @var list<int> $input */` は、「全件が条件成立」テストでリテラル配列に対する比較が `smaller.alwaysTrue` と判定されるのを避けるためです (外すと level 10 が落ちることを確認済み)

Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
