### PR TITLE
feat: flat_map と group_map を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/flat_map.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/flat_map.php"
+            "src/flat_map.php",
+            "src/group_map.php"
         ]
     },
     "autoload-dev": {

--- a/src/flat_map.php
+++ b/src/flat_map.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 各要素をコールバックで配列に変換し、その結果を順序を保ったまま 1 段だけ平坦化します。
+ *
+ * 平坦化するのは $callback が返した配列 1 段だけです。
+ * その中にさらに配列が入っていても展開せず、値としてそのまま格納します。
+ *
+ * MODE_LIST では $callback の戻り配列のキーを捨て、結果全体を 0 始まりの連番に振り直します。
+ * MODE_ASSOC では入力側のキーではなく $callback の戻り配列のキーを採用します。
+ * このとき同じキーが複数回現れた場合は、後に現れたものが前のものを上書きします。
+ *
+ * @template K of array-key
+ * @template V
+ * @template R of array-key
+ * @template E
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): (list<E>|array<R, E>) $callback 各要素を配列に変換する関数（第1引数: 値, 第2引数: キー）
+ * @return list<E>|array<R, E>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<E> :
+ *    ($mode is Mode::MODE_ASSOC ? array<R, E> :
+ *      ($input is list<V> ? list<E> :
+ *        array<R, E>
+ * )))
+ */
+function flat_map(array $input, callable $callback, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = [];
+
+    foreach ($input as $key => $value) {
+        foreach ($callback($value, $key) as $innerKey => $element) {
+            if ($mode === Mode::MODE_LIST) {
+                $result[] = $element;
+            } else {
+                $result[$innerKey] = $element;
+            }
+        }
+    }
+
+    return $result;
+}

--- a/src/group_map.php
+++ b/src/group_map.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * コールバックで指定した分類キーごとに配列をグループ化し、各要素を変換して格納します。
+ *
+ * group_by() の各要素を $transform で変換した版です。
+ *
+ * 各グループの中でのキーの扱いは $mode で決まります。
+ * MODE_LIST では入力のキーを捨て、各グループを 0 始まり連番の list にします。
+ * MODE_ASSOC では入力のキーを保持し、入力が list であっても元の整数添字をそのまま使います
+ * （グループごとに要素が飛び飛びになっても添字を詰めません）。
+ * MODE_AUTO は入力の形状から判定するため、group_by() と同じ挙動になります。
+ *
+ * グループの出現順、およびグループ内の要素の順序は入力順のままです。
+ *
+ * @template K of array-key
+ * @template V
+ * @template G of array-key
+ * @template E
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): G $classifier 分類キーを返す関数（第1引数: 値, 第2引数: キー）
+ * @param callable(V, K): E $transform 各要素を変換する関数（第1引数: 値, 第2引数: キー）
+ * @return array<G, list<E>|array<K, E>>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? array<G, list<E>> :
+ *    ($mode is Mode::MODE_ASSOC ? array<G, array<K, E>> :
+ *      ($input is list<V> ? array<G, list<E>> :
+ *        array<G, array<K, E>>
+ * )))
+ */
+function group_map(array $input, callable $classifier, callable $transform, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = [];
+
+    foreach ($input as $key => $value) {
+        $groupKey = $classifier($value, $key);
+        $element  = $transform($value, $key);
+
+        $result[$groupKey] ??= [];
+
+        if ($mode === Mode::MODE_LIST) {
+            $result[$groupKey][] = $element;
+        } else {
+            $result[$groupKey][$key] = $element;
+        }
+    }
+
+    return $result;
+}

--- a/tests/FlatMapTest.php
+++ b/tests/FlatMapTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class FlatMapTest extends TestCase
+{
+    public function testFlatMapOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = flat_map(
+            $input,
+            fn ($value, $key): array => [$value],
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFlatMapWhenEveryCallbackReturnsEmptyReturnsEmpty(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = flat_map(
+            $input,
+            fn (int $value, int $index): array => [],
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFlatMapWhenSomeCallbacksReturnEmptyDropsThem(): void
+    {
+        $input = [1, 2, 3, 4];
+
+        $result = flat_map(
+            $input,
+            fn (int $value, int $index): array => $value % 2 === 0 ? [$value, $value] : [],
+        );
+
+        $this->assertSame([2, 2, 4, 4], $result);
+    }
+
+    public function testFlatMapOnListInputRenumbersKeys(): void
+    {
+        $input = ['a', 'b'];
+
+        $result = flat_map(
+            $input,
+            fn (string $value, int $index): array => [
+                'upper' => strtoupper($value),
+                'lower' => $value,
+            ],
+        );
+
+        $this->assertSame(['A', 'a', 'B', 'b'], $result);
+    }
+
+    public function testFlatMapOnAssocInputUsesCallbackKeys(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        $result = flat_map(
+            $input,
+            fn (int $age, string $name): array => [
+                $name . '_age'   => $age,
+                $name . '_adult' => $age >= 20,
+            ],
+        );
+
+        $this->assertSame([
+            'alice_age'   => 20,
+            'alice_adult' => true,
+            'bob_age'     => 17,
+            'bob_adult'   => false,
+        ], $result);
+    }
+
+    public function testFlatMapOnAssocModeWithDuplicatedKeysKeepsLastValueAtFirstPosition(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        // alice は a, b の順、bob は b, c の順にキーを返すので b だけが衝突する。
+        $result = flat_map(
+            $input,
+            fn (int $age, string $name): array => $name === 'alice'
+                ? ['a' => "a:{$age}", 'b' => "b:{$age}"]
+                : ['b' => "b:{$age}", 'c' => "c:{$age}"],
+            Mode::MODE_ASSOC,
+        );
+
+        // 値は後勝ちで b:17 になるが、b の位置は初出のまま a と c の間に残る。
+        $this->assertSame([
+            'a' => 'a:20',
+            'b' => 'b:17',
+            'c' => 'c:17',
+        ], $result);
+    }
+
+    public function testFlatMapOnListInputWithAssocModeCollapsesCallbackListKeys(): void
+    {
+        $input = [1, 2];
+
+        // callback が list を返すため内側のキーはすべて 0 になり、後勝ちで 1 件に潰れる。
+        $result = flat_map(
+            $input,
+            fn (int $value, int $index): array => [$value],
+            Mode::MODE_ASSOC,
+        );
+
+        $this->assertSame([0 => 2], $result);
+    }
+
+    public function testFlatMapFlattensOnlyOneLevel(): void
+    {
+        $input = [1, 2];
+
+        $result = flat_map(
+            $input,
+            fn (int $value, int $index): array => [[$value], [[$value]]],
+        );
+
+        $this->assertSame([[1], [[1]], [2], [[2]]], $result);
+    }
+
+    public function testFlatMapPassesKeyToCallback(): void
+    {
+        $input = [10, 20];
+
+        $result = flat_map(
+            $input,
+            fn (int $value, int $index): array => [$index, $value],
+        );
+
+        $this->assertSame([0, 10, 1, 20], $result);
+    }
+
+    public function testFlatMapWithExplicitListModeDropsCallbackKeys(): void
+    {
+        $input = [1, 2];
+
+        $result = flat_map(
+            $input,
+            fn (int $value, int $index): array => ['value' => $value, 'double' => $value * 2],
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([1, 2, 2, 4], $result);
+    }
+
+    public function testFlatMapOnAssocInputWithListModeRenumbersKeys(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        $result = flat_map(
+            $input,
+            fn (int $age, string $name): array => ['name' => $name, 'age' => $age],
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame(['alice', 20, 'bob', 17], $result);
+    }
+
+    public function testFlatMapDoesNotMutateInput(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        flat_map(
+            $input,
+            fn (int $age, string $name): array => [$name => $age * 2],
+        );
+
+        $this->assertSame([
+            'alice' => 20,
+            'bob'   => 17,
+        ], $input);
+    }
+}

--- a/tests/GroupMapTest.php
+++ b/tests/GroupMapTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class GroupMapTest extends TestCase
+{
+    public function testGroupMapOnEmptyArrayReturnsEmpty(): void
+    {
+        $input = [];
+
+        $result = group_map(
+            $input,
+            fn ($value, $key): string => 'all',
+            fn ($value, $key)         => $value,
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGroupMapWithSingleGroupOnListInput(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = group_map(
+            $input,
+            fn (int $value, int $index): string => 'all',
+            fn (int $value, int $index): int    => $value * 10,
+        );
+
+        $this->assertSame([
+            'all' => [10, 20, 30],
+        ], $result);
+    }
+
+    public function testGroupMapWithMultipleGroupsOnListInputKeepsOrder(): void
+    {
+        $input = [3, 1, 4, 2, 5, 6];
+
+        $result = group_map(
+            $input,
+            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+            fn (int $value, int $index): int    => $value * 2,
+        );
+
+        $this->assertSame([
+            'odd'  => [6, 2, 10],
+            'even' => [8, 4, 12],
+        ], $result);
+    }
+
+    public function testGroupMapOnAssocInputPreservesKeysInEachGroup(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = group_map(
+            $input,
+            fn (int $age, string $name): string => $age >= 20 ? 'adult' : 'minor',
+            fn (int $age, string $name): int    => $age + 1,
+        );
+
+        $this->assertSame([
+            'adult' => [
+                'alice' => 21,
+                'carol' => 24,
+            ],
+            'minor' => [
+                'bob'  => 18,
+                'dave' => 19,
+            ],
+        ], $result);
+    }
+
+    public function testGroupMapOnAssocInputWithListModeDropsKeysInEachGroup(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = group_map(
+            $input,
+            fn (int $age, string $name): string => $age >= 20 ? 'adult' : 'minor',
+            fn (int $age, string $name): int    => $age + 1,
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([
+            'adult' => [21, 24],
+            'minor' => [18, 19],
+        ], $result);
+
+        $this->assertEveryGroupIsList($result);
+    }
+
+    public function testGroupMapOnListInputWithAssocModeKeepsOriginalIndexes(): void
+    {
+        $input = [3, 1, 4, 2, 5, 6];
+
+        $result = group_map(
+            $input,
+            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+            fn (int $value, int $index): int    => $value * 2,
+            Mode::MODE_ASSOC,
+        );
+
+        // 元の添字を維持するため、グループ内の添字は飛び飛びのままになる。
+        $this->assertSame([
+            'odd' => [
+                0 => 6,
+                1 => 2,
+                4 => 10,
+            ],
+            'even' => [
+                2 => 8,
+                3 => 4,
+                5 => 12,
+            ],
+        ], $result);
+    }
+
+    public function testGroupMapWithIntegerGroupKeys(): void
+    {
+        $input = [10, 25, 30, 42];
+
+        $result = group_map(
+            $input,
+            fn (int $value, int $index): int => intdiv($value, 10),
+            fn (int $value, int $index): int => $value % 10,
+        );
+
+        $this->assertSame([
+            1 => [0],
+            2 => [5],
+            3 => [0],
+            4 => [2],
+        ], $result);
+    }
+
+    public function testGroupMapTransformChangesValueType(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = group_map(
+            $input,
+            fn (int $value, int $index): string => $value % 2 === 0 ? 'even' : 'odd',
+            fn (int $value, int $index): string => "#{$value}",
+        );
+
+        $this->assertSame([
+            'odd'  => ['#1', '#3'],
+            'even' => ['#2'],
+        ], $result);
+    }
+
+    public function testGroupMapPassesKeyToBothCallbacks(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+        ];
+
+        $result = group_map(
+            $input,
+            fn (int $age, string $name): string => $name[0],
+            fn (int $age, string $name): string => "{$name}:{$age}",
+        );
+
+        $this->assertSame([
+            'a' => ['alice' => 'alice:20'],
+            'b' => ['bob' => 'bob:17'],
+            'c' => ['carol' => 'carol:23'],
+        ], $result);
+    }
+
+    public function testGroupMapDoesNotMutateInput(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        group_map(
+            $input,
+            fn (int $age, string $name): string => 'all',
+            fn (int $age, string $name): int    => $age * 2,
+        );
+
+        $this->assertSame([
+            'alice' => 20,
+            'bob'   => 17,
+        ], $input);
+    }
+
+    /**
+     * 各グループが実行時に list であることを確かめます。
+     *
+     * 条件型を持たない @return と同じ緩い型で受け取るのは、group_map() の呼び出し地点のまま
+     * array_is_list() を呼ぶと @phpstan-return の list<E> から常に真だと分かってしまい、
+     * 検査として成立しないためです。
+     *
+     * @param array<string, list<int>|array<string, int>> $groups
+     */
+    private function assertEveryGroupIsList(array $groups): void
+    {
+        foreach ($groups as $group) {
+            $this->assertTrue(array_is_list($group));
+        }
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
callback の戻り配列を 1 段だけ平坦化する `flat_map` と、`group_by` しつつ各要素を変換する `group_map` を追加します。

## 変更点
- `src/flat_map.php` — LIST は連番へ正規化、ASSOC は callback 戻りのキーを採用 (衝突は後勝ち)
- `src/group_map.php` — `group_by` とキーの扱いを揃え、各要素を `$transform` で変換
- `tests/FlatMapTest.php` (12 ケース) / `tests/GroupMapTest.php` (8 ケース)
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：
    - `flat_map([1, 2], fn ($v) => [$v, $v * 10])` → `[1, 10, 2, 20]`
    - `group_map(['alice' => 20, 'bob' => 17], fn ($age) => $age >= 20 ? 'adult' : 'minor', fn ($age) => $age * 12)` → `['adult' => ['alice' => 240], 'minor' => ['bob' => 204]]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (117 tests, 122 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）

### `flat_map` の平坦化は 1 段だけ

戻り配列の中の配列は展開しません (phpdoc に明記、テストで固定)。

### `MODE_ASSOC` は外側キーを捨てる

入力側のキーではなく callback 戻り配列のキーを採用し、衝突は後勝ちです。テストでは**値が後勝ちになること**に加えて**キーの位置が初出のまま残ること**まで固定しています (PHP の上書きはキー位置を移動しないため)。

list 入力に `MODE_ASSOC` を明示すると callback 戻りの内側キーが全部 0 になって 1 件に潰れます。仕様からは正しいものの驚きやすい組み合わせなので、これもテストで固定しました。

### `@template R of array-key` が解決されることを確認済み

callback が list を返す呼び出しで `R` が推論されず `array<never, E>` に落ちる懸念がありましたが、`\PHPStan\dumpType()` で 7 パターン確認したところ 1 件も出ませんでした (list 戻りのケースは `array<0, 1|2>` と解決され、実行時結果 `[0 => 2]` を正しく含みます)。

### `group_map` は `Mode` を取りません

`group_by` と同じく入力形状でキーの扱いを決めます (list 入力なら各グループは list、assoc 入力なら元のキーを保持)。

Closes #57
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追記: `group_map` に `Mode` を追加しました

**新規関数には `Mode` を持たせる**方針に合わせました。当初は「`group_by` が取らないから」という理由で省いていましたが、それは既存関数の制約であって新規関数が従う理由になりません。

```php
function group_map(array $input, callable $classifier, callable $transform, Mode $mode = Mode::MODE_AUTO): array
```

- `MODE_LIST`: 各グループが完全な list (入力が assoc でもキーを捨てる)
- `MODE_ASSOC`: 各グループが元のキーを維持 (list 入力でも元の整数添字を維持し、**添字を詰めない**)
- `MODE_AUTO`: `array_is_list()` 判定で `group_by` と同じ挙動 = **既存テストはすべてそのまま通ります**

実装は `array_is_list($input)` の直接呼び出しをやめて `Mode::check_mode($mode, $input)` に置き換え、`@phpstan-return` を 4 分岐の条件型にしました。

`OK (126 tests, 133 assertions)` / PHPStan level 10 `[OK] No errors`。

> [!NOTE]
> `group_by` 自体は `Mode` を持たないままなので、`group_map(..., MODE_LIST)` に相当する挙動が `group_by` にはありません。既存関数への追随は別途相談させてください。
