### PR TITLE
feat: partition と partition_map を追加する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
             "src/last_option.php",
             "src/intersect.php",
             "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/chunk_by.php",
+            "src/partition.php"
         ]
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
             "src/intersect.php",
             "src/map_keys.php",
             "src/chunk_by.php",
-            "src/partition.php"
+            "src/partition.php",
+            "src/partition_map.php"
         ]
     },
     "autoload-dev": {

--- a/src/partition.php
+++ b/src/partition.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * 配列を述語で 2 つに分割します。
+ *
+ * 添字 0 が述語を満たした要素、添字 1 が満たさなかった要素です。
+ * どちらの側も元の並び順を保ち、2 つを合わせると入力の全要素になります。
+ *
+ * @template K of array-key
+ * @template V
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): bool $callback 振り分ける条件（true なら添字 0 側、false なら添字 1 側）
+ * @return array{0: list<V>|array<K, V>, 1: list<V>|array<K, V>}
+ * @phpstan-return ($mode is Mode::MODE_LIST ? array{0: list<V>, 1: list<V>} :
+ *     ($mode is Mode::MODE_ASSOC ? array{0: array<K, V>, 1: array<K, V>} :
+ *       ($input is list<V> ? array{0: list<V>, 1: list<V>} :
+ *         array{0: array<K, V>, 1: array<K, V>}
+ *  )))
+ */
+function partition(array $input, callable $callback, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = [[], []];
+
+    foreach ($input as $key => $value) {
+        $side = $callback($value, $key) ? 0 : 1;
+
+        if ($mode === Mode::MODE_LIST) {
+            $result[$side][] = $value;
+        } else {
+            $result[$side][$key] = $value;
+        }
+    }
+
+    return $result;
+}

--- a/src/partition_map.php
+++ b/src/partition_map.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+/**
+ * partition の分類と変換を同時に行う版です。
+ *
+ * コールバックは「振り分け先」と「変換後の値」の組を返します。
+ * partition と同じく添字 0 が true 側、添字 1 が false 側で、振り分け先は truthy 判定です。
+ * 保存されるのは値ではなく個数と順序です。入力の各要素は変換後の値としてどちらか一方に 1 回だけ現れ、
+ * 両側の要素数の合計は入力の要素数と一致します。どちらの側も入力の並び順を保ちます。
+ *
+ * 左右で異なる型の値を返しても構いませんが、左右の値は同じ型パラメータ E として扱われるため、
+ * PHPStan 上は両側とも union として推論されます。
+ *
+ * @template K of array-key
+ * @template V
+ * @template E
+ *
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): array{0: bool, 1: E} $callback 振り分け先と変換後の値の組を返す関数（第1要素が true なら添字 0 側、false なら添字 1 側）
+ * @return array{0: list<E>|array<K, E>, 1: list<E>|array<K, E>}
+ * @phpstan-return ($mode is Mode::MODE_LIST ? array{0: list<E>, 1: list<E>} :
+ *     ($mode is Mode::MODE_ASSOC ? array{0: array<K, E>, 1: array<K, E>} :
+ *       ($input is list<V> ? array{0: list<E>, 1: list<E>} :
+ *         array{0: array<K, E>, 1: array<K, E>}
+ *  )))
+ */
+function partition_map(array $input, callable $callback, Mode $mode = Mode::MODE_AUTO): array
+{
+    $mode = Mode::check_mode($mode, $input);
+
+    $result = [[], []];
+
+    foreach ($input as $key => $value) {
+        $classified = $callback($value, $key);
+        $side       = $classified[0] ? 0 : 1;
+
+        if ($mode === Mode::MODE_LIST) {
+            $result[$side][] = $classified[1];
+        } else {
+            $result[$side][$key] = $classified[1];
+        }
+    }
+
+    return $result;
+}

--- a/tests/PartitionMapTest.php
+++ b/tests/PartitionMapTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class PartitionMapTest extends TestCase
+{
+    public function testPartitionMapOnEmptyArrayReturnsTwoEmptyArrays(): void
+    {
+        $input = [];
+
+        $result = partition_map(
+            $input,
+            fn (mixed $value, int|string $key): array => [true, $value],
+        );
+
+        $this->assertSame([[], []], $result);
+    }
+
+    public function testPartitionMapWhenAllElementsGoLeftReturnsEmptyRightSide(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = partition_map(
+            $input,
+            fn (int $value): array => [true, $value * 2],
+        );
+
+        $this->assertSame([[2, 4, 6], []], $result);
+    }
+
+    public function testPartitionMapWhenAllElementsGoRightReturnsEmptyLeftSide(): void
+    {
+        $input = [1, 2, 3];
+
+        $result = partition_map(
+            $input,
+            fn (int $value): array => [false, "v{$value}"],
+        );
+
+        $this->assertSame([[], ['v1', 'v2', 'v3']], $result);
+    }
+
+    public function testPartitionMapWithMixedResultsKeepsDifferentValueTypesAndOrder(): void
+    {
+        $input = [3, 1, 4, 2, 5, 6];
+
+        $result = partition_map(
+            $input,
+            fn (int $value): array => $value % 2 === 0
+                ? [true, $value * 10]
+                : [false, "odd:{$value}"],
+        );
+
+        $this->assertSame([
+            [40, 20, 60],
+            ['odd:3', 'odd:1', 'odd:5'],
+        ], $result);
+    }
+
+    public function testPartitionMapOnAssocInputPreservesKeysInBothSides(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = partition_map(
+            $input,
+            fn (int $age): array => $age >= 20
+                ? [true, $age]
+                : [false, "minor({$age})"],
+        );
+
+        $this->assertSame([
+            [
+                'alice' => 20,
+                'carol' => 23,
+            ],
+            [
+                'bob'  => 'minor(17)',
+                'dave' => 'minor(18)',
+            ],
+        ], $result);
+    }
+
+    public function testPartitionMapOnListInputWithAssocModePreservesIndexes(): void
+    {
+        $input = [3, 1, 4, 2];
+
+        $result = partition_map(
+            $input,
+            fn (int $value): array => $value % 2 === 0
+                ? [true, $value * 10]
+                : [false, "odd:{$value}"],
+            Mode::MODE_ASSOC,
+        );
+
+        $this->assertSame([
+            [2 => 40, 3 => 20],
+            [0 => 'odd:3', 1 => 'odd:1'],
+        ], $result);
+    }
+
+    public function testPartitionMapOnAssocInputWithListModeRenumbersBothSides(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = partition_map(
+            $input,
+            fn (int $age): array => $age >= 20
+                ? [true, $age]
+                : [false, "minor({$age})"],
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([
+            [20, 23],
+            ['minor(17)', 'minor(18)'],
+        ], $result);
+    }
+
+    public function testPartitionMapPassesKeyToCallback(): void
+    {
+        $input = [10, 20, 30, 40];
+
+        $result = partition_map(
+            $input,
+            fn (int $value, int $index): array => $index % 2 === 0
+                ? [true, $index]
+                : [false, $value],
+        );
+
+        $this->assertSame([[0, 2], [20, 40]], $result);
+    }
+
+    public function testPartitionMapKeepsTotalCountOfInput(): void
+    {
+        $input = [
+            'a' => 5,
+            'b' => 8,
+            'c' => 13,
+            'd' => 21,
+            'e' => 34,
+            'f' => 55,
+        ];
+
+        [$left, $right] = partition_map(
+            $input,
+            fn (int $value): array => $value % 2 === 0
+                ? [true, $value]
+                : [false, (string) $value],
+        );
+
+        $this->assertSame(\count($input), \count($left) + \count($right));
+    }
+
+    public function testPartitionMapAcceptsCallbackDeclaredByContract(): void
+    {
+        $input = [3, 1, 4, 2, 6];
+
+        // 契約どおりの戻り値型を宣言したコールバックが $callback の @param 型を
+        // 通過することを PHPStan level 10 で確かめる。
+        /**
+         * @return array{0: true, 1: int}|array{0: false, 1: string}
+         */
+        $classify = static fn (int $value): array => $value % 2 === 0
+            ? [true, $value * 10]
+            : [false, "odd:{$value}"];
+
+        $result = partition_map($input, $classify);
+
+        $this->assertSame([
+            [40, 20, 60],
+            ['odd:3', 'odd:1'],
+        ], $result);
+    }
+
+    public function testPartitionMapInfersUnionTypeOnBothSides(): void
+    {
+        $input = [3, 1, 4, 2, 6];
+
+        [$left, $right] = partition_map(
+            $input,
+            fn (int $value): array => $value % 2 === 0
+                ? [true, $value * 10]
+                : [false, "odd:{$value}"],
+        );
+
+        $this->assertSame(3, $this->acceptsUnionList($left));
+        $this->assertSame(2, $this->acceptsUnionList($right));
+    }
+
+    public function testPartitionMapDoesNotModifyInput(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        partition_map(
+            $input,
+            fn (int $age): array => $age >= 20
+                ? [true, $age]
+                : [false, "minor({$age})"],
+        );
+
+        $this->assertSame([
+            'alice' => 20,
+            'bob'   => 17,
+        ], $input);
+    }
+
+    /**
+     * 左右の値は単一の型パラメータ E として扱われるため、静的にはどちらの側も union に推論される。
+     *
+     * 判別可能 union（array{0: true, 1: L}|array{0: false, 1: R}）から L と R を別々に推論させる
+     * 試みは PHPStan 2.1 では成立しなかった（両方とも union に解決される）。
+     * 型パラメータを L / R の 2 本に分ける案を再検討する前に、ここで期待値を確かめること。
+     *
+     * @param list<int|string> $values
+     */
+    private function acceptsUnionList(array $values): int
+    {
+        return \count($values);
+    }
+}

--- a/tests/PartitionTest.php
+++ b/tests/PartitionTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oyashiro846\Phollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class PartitionTest extends TestCase
+{
+    public function testPartitionOnEmptyArrayReturnsTwoEmptyArrays(): void
+    {
+        $input = [];
+
+        $result = partition(
+            $input,
+            fn (mixed $value, int|string $key): bool => true,
+        );
+
+        $this->assertSame([[], []], $result);
+    }
+
+    public function testPartitionWhenAllElementsMatchReturnsEmptyFalseSide(): void
+    {
+        /** @var list<int> $input 定数畳み込みで述語が常に true と判定されるのを避ける */
+        $input = [1, 2, 3];
+
+        $result = partition(
+            $input,
+            fn (int $value): bool => $value > 0,
+        );
+
+        $this->assertSame([[1, 2, 3], []], $result);
+    }
+
+    public function testPartitionWhenNoElementMatchesReturnsEmptyTrueSide(): void
+    {
+        /** @var list<int> $input 定数畳み込みで述語が常に false と判定されるのを避ける */
+        $input = [1, 2, 3];
+
+        $result = partition(
+            $input,
+            fn (int $value): bool => $value > 10,
+        );
+
+        $this->assertSame([[], [1, 2, 3]], $result);
+    }
+
+    public function testPartitionOnListInputKeepsOrderInBothSides(): void
+    {
+        $input = [3, 1, 4, 2, 5, 6];
+
+        $result = partition(
+            $input,
+            fn (int $value): bool => $value % 2 === 0,
+        );
+
+        $this->assertSame([[4, 2, 6], [3, 1, 5]], $result);
+    }
+
+    public function testPartitionOnAssocInputPreservesKeysInBothSides(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = partition(
+            $input,
+            fn (int $age, string $name): bool => $age >= 20,
+        );
+
+        $this->assertSame([
+            [
+                'alice' => 20,
+                'carol' => 23,
+            ],
+            [
+                'bob'  => 17,
+                'dave' => 18,
+            ],
+        ], $result);
+    }
+
+    public function testPartitionOnAssocInputWithListModeRenumbersBothSides(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+            'carol' => 23,
+            'dave'  => 18,
+        ];
+
+        $result = partition(
+            $input,
+            fn (int $age): bool => $age >= 20,
+            Mode::MODE_LIST,
+        );
+
+        $this->assertSame([[20, 23], [17, 18]], $result);
+    }
+
+    public function testPartitionOnListInputWithAssocModePreservesIndexes(): void
+    {
+        $input = [3, 1, 4, 2];
+
+        $result = partition(
+            $input,
+            fn (int $value): bool => $value % 2 === 0,
+            Mode::MODE_ASSOC,
+        );
+
+        $this->assertSame([
+            [2 => 4, 3 => 2],
+            [0 => 3, 1 => 1],
+        ], $result);
+    }
+
+    public function testPartitionPassesKeyToCallback(): void
+    {
+        $input = [10, 20, 30, 40];
+
+        $result = partition(
+            $input,
+            fn (int $value, int $index): bool => $index % 2 === 0,
+        );
+
+        $this->assertSame([[10, 30], [20, 40]], $result);
+    }
+
+    public function testPartitionKeepsTotalCountOfInput(): void
+    {
+        $input = [
+            'a' => 5,
+            'b' => 8,
+            'c' => 13,
+            'd' => 21,
+            'e' => 34,
+            'f' => 55,
+        ];
+
+        [$matched, $unmatched] = partition(
+            $input,
+            fn (int $value): bool => $value % 2 === 0,
+        );
+
+        $this->assertSame(\count($input), \count($matched) + \count($unmatched));
+    }
+
+    public function testPartitionDoesNotModifyInput(): void
+    {
+        $input = [
+            'alice' => 20,
+            'bob'   => 17,
+        ];
+
+        partition(
+            $input,
+            fn (int $age): bool => $age >= 20,
+        );
+
+        $this->assertSame([
+            'alice' => 20,
+            'bob'   => 17,
+        ], $input);
+    }
+}


### PR DESCRIPTION
## 概要（What / Why）
述語で 2 分割する `partition` と、分割と変換を同時に行う `partition_map` を追加します。

## 変更点
- `src/partition.php` — `array{0: true側, 1: false側}`。両側とも元の順序を維持
- `src/partition_map.php` — callback が `array{0: bool, 1: 変換後の値}` を返す。1 パスで振り分けと変換
- `tests/PartitionTest.php` / `tests/PartitionMapTest.php`
- `composer.json` の `autoload.files` に 2 件追加

## 動作確認
- 手動：
    - `partition([1, 2, 3, 4], fn ($v) => $v % 2 === 0)` → `[[2, 4], [1, 3]]`
    - `partition_map([20, 17], fn ($v) => $v >= 20 ? [true, $v] : [false, "minor($v)"])` → `[[20], ['minor(17)']]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (119 tests, 125 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 33 files`

## 補足（任意）

### `Either` を作らずタプルで表現しています

Scala の `partitionMap` は `Either` を返しますが、README の設計思想「新しいクラスを定義しない」に従い `array{0: bool, 1: 値}` にしました。`partition` と同じく **添字 0 が true 側**で規約を揃えています。

### `@template` を 1 本にした理由 (検証結果つき)

当初は `@template L` / `@template R` を切り、判別可能 union (`array{0: true, 1: L}|array{0: false, 1: R}`) から左右の型を分けようとしましたが、**PHPStan 2.x はこの分離推論をしません**。`\PHPStan\dumpType()` で確認した結果:

- callback の型自体は union のまま保たれる (`Closure(int): (array{false, non-falsy-string}|array{true, int})`)
- それでも呼び出し結果は両側とも `list<int|non-falsy-string>`
- callback を介さない最小形でも `L` と `R` の両方に union 全体が推論される

潰れているのは関数本体ではなくテンプレート推論そのものなので、本体に `/** @var L */` と言い切っても利用者側には分離が届きません。動かない型注釈は読み手に嘘をつくので、`@template E` 1 本に畳んで phpdoc に「左右で異なる型を返しても PHPStan 上は union として推論される」と明記しました。

同時に `partition_map` の実装を `partition` と同じ形 (`$result = [[], []]` + `$side` で振り分け) に揃えられたので、姉妹関数の非対称も解消しています。

この検証の経緯は `tests/PartitionMapTest.php` のヘルパーの docblock に残してあります (次に型パラメータを 2 本に分けたくなった人が同じ検証を繰り返さずに済むように)。

### その他

- 両側の件数の合計が入力件数と一致することを **assoc 入力で** テストしています (キー衝突が概念上ありうるのは assoc 側なので)
- 振り分けは truthy 判定です。契約どおり bool を返す限り厳密比較との差はありません (phpdoc に明記)
- `@phpstan-param` の条件型は付けていません (「assoc 入力 + `MODE_LIST`」が型エラーになるため。`slice.php` / `map.php` / `intersect.php` と同じ形)

Closes #59
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
