### PR TITLE
refactor: autoload の関数登録を src/_functions.php に集約する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,34 +4,20 @@
     "type": "library",
     "license": "MIT",
     "require": {
-      "php": ">=8.4"
+        "php": ">=8.4"
     },
     "autoload": {
         "psr-4": {
             "Oyashiro846\\Phollection\\": "src/"
         },
         "files": [
-            "src/filter.php",
-            "src/any.php",
-            "src/group_by.php",
-            "src/tail.php",
-            "src/init.php",
-            "src/collect.php",
-            "src/slice.php",
-            "src/unique.php",
-            "src/reduce.php",
-            "src/map.php",
-            "src/head_option.php",
-            "src/last_option.php",
-            "src/intersect.php",
-            "src/map_keys.php",
-            "src/chunk_by.php"
+            "src/_functions.php"
         ]
     },
     "autoload-dev": {
-      "psr-4": {
-        "Oyashiro846\\Phollection\\": "tests/"
-      }
+        "psr-4": {
+            "Oyashiro846\\Phollection\\": "tests/"
+        }
     },
     "authors": [
         {

--- a/src/_functions.php
+++ b/src/_functions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * src/ 配下の関数定義ファイルをここでまとめて読み込みます。
+ *
+ * composer.json の autoload.files に 1 ファイルずつ列挙すると、関数を追加する PR が
+ * すべて同じ行 (配列の末尾) で衝突します。読み込みをこのファイルへ集約し、
+ * 並び順をファイル名の昇順に固定することで、追加位置が分散して衝突しにくくなります。
+ *
+ * 新しい関数を追加するときは、composer.json ではなくこのファイルへ
+ * **昇順の正しい位置に** 1 行足してください。クラスは PSR-4 で解決されます。
+ */
+
+require_once __DIR__ . '/any.php';
+require_once __DIR__ . '/chunk_by.php';
+require_once __DIR__ . '/collect.php';
+require_once __DIR__ . '/filter.php';
+require_once __DIR__ . '/group_by.php';
+require_once __DIR__ . '/head_option.php';
+require_once __DIR__ . '/init.php';
+require_once __DIR__ . '/intersect.php';
+require_once __DIR__ . '/last_option.php';
+require_once __DIR__ . '/map.php';
+require_once __DIR__ . '/map_keys.php';
+require_once __DIR__ . '/reduce.php';
+require_once __DIR__ . '/slice.php';
+require_once __DIR__ . '/tail.php';
+require_once __DIR__ . '/unique.php';


### PR DESCRIPTION
## 概要（What / Why）
関数の autoload 登録を `src/_functions.php` に集約し、`composer.json` 側を 1 エントリに固定します。
`autoload.files` に 1 ファイルずつ列挙していると、**関数を追加する PR がすべて配列の末尾で衝突します**。

## 問題

現在 open な 11 本の関数追加 PR は、全部が `composer.json` の同じ行を触っています。
実際に #75 (chunk_by) が master にマージされた時点で、**残り 11 本すべてが衝突しました**
(`git merge-tree` で確認)。1 本マージするごとに残りを rebase する運用になります。

```
$ git merge-tree --write-tree origin/master origin/javakky/sort-by
CONFLICT (content): Merge conflict in composer.json
```

## 変更点
- `src/_functions.php` を追加 — `src/` 配下の関数定義ファイルを `require_once` で読み込む。**ファイル名の昇順**に固定
- `composer.json` の `autoload.files` を `["src/_functions.php"]` の 1 エントリにする

以降、関数を追加するときは `composer.json` ではなく `src/_functions.php` に**昇順の正しい位置へ** 1 行足します。
追加位置が名前で分散するため、同時に走る PR どうしが同じ行を触りにくくなります。

## 動作確認
- 手動：
    - `composer dump-autoload` / `composer dump-autoload -o` (optimized) の両方で全関数が見えることを確認
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (104 tests, 109 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 32 files`

## 補足（任意）

### `glob()` 案は計測して落としました

`src/_functions.php` で `glob(__DIR__ . '/*.php')` を走査すれば追加時に**どのファイルも触らずに済む** (衝突が構造的にゼロ) のですが、autoload のロード時間を実測したら悪化しました。

| 方式 | ロード時間 (CLI 20 回平均) |
|---|---|
| 現在の master (明示列挙) | 3.06 ms |
| **本 PR (単一エントリ + 明示 require)** | **3.13 ms** |
| `glob()` 走査 | 4.04 ms |

`glob()` のディレクトリ走査は opcache でキャッシュされないので、ライブラリ利用者が毎リクエスト払うことになります。+1ms を払って衝突を完全にゼロにするより、コストなしで衝突を分散させる方を採りました。

### 昇順でも衝突しうるケース

名前が隣接する関数が別々の PR で同時に追加されると、まだ衝突します (例: `drop` と `drop_while`)。ただし解決は「両方の行を残す」で機械的に済み、衝突する PR の本数自体が大きく減ります。

### マージ順のお願い

この PR を**先にマージしていただけると**、残り 11 本の PR から `composer.json` の変更を落として `src/_functions.php` への 1 行追加に置き換えられます (こちらで rebase します)。後にすると 11 本ぶんの衝突解決が発生します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
