### PR TITLE
feat: chunk_by に Mode を追加して assoc 対応にする

### DIFF
--- a/src/chunk_by.php
+++ b/src/chunk_by.php
@@ -10,33 +10,61 @@ namespace Oyashiro846\Phollection;
  * PHP 標準の `array_chunk` が指定サイズで等分するのに対し、 本関数は隣接する要素間で
  * `$callback` の結果が変わる位置で chunk を切ります。 全要素数は保存され、 順序も維持されます。
  *
+ * PHP の配列は挿入順を保持するため associative array でも「隣接する要素」は定義できます。
+ * よって入力は list でも associative array でも構いません。 chunk の内部のキーの扱いは
+ * $mode に従い、 `MODE_LIST` なら 0 始まりの連番へ振り直し、 `MODE_ASSOC` なら元のキーを維持します。
+ * 外側 (chunk の並び) は $mode によらず常に list です。
+ *
  * 例:
  * ```
  * chunk_by([1, 1, 2, 3, 3, 1], fn (int $v): int => $v);
  * // => [[1, 1], [2], [3, 3], [1]]
+ *
+ * chunk_by(['a' => 1, 'b' => 1, 'c' => 2], fn (int $v): int => $v);
+ * // => [['a' => 1, 'b' => 1], ['c' => 2]]
  * ```
  *
+ * @template K of array-key
  * @template V
  * @template R
  *
- * @param list<V> $input  対象の配列 (list 前提。 associative array は順序保証が無いため非対応)
- * @param callable(V): R $callback  各要素を chunk キーに変換する。 戻り値は `===` で比較される。
- * @return list<non-empty-list<V>>
+ * @param list<V>|array<K, V> $input 対象の配列
+ * @param callable(V, K): R $callback  各要素を chunk キーに変換する。 戻り値は `===` で比較される。
+ * 空の chunk は作らないが、 assoc 側は `non-empty-array<never, never>` が
+ * `chunk_by([], ...)` の呼び出しで unresolvable になるため `non-empty` を付けていない。
+ *
+ * @return list<non-empty-list<V>>|list<array<K, V>>
+ * @phpstan-return ($mode is Mode::MODE_LIST ? list<non-empty-list<V>> :
+ *     ($mode is Mode::MODE_ASSOC ? list<array<K, V>> :
+ *       ($input is list<V> ? list<non-empty-list<V>> :
+ *         list<array<K, V>>
+ *  )))
  */
-function chunk_by(array $input, callable $callback): array
+function chunk_by(array $input, callable $callback, Mode $mode = Mode::MODE_AUTO): array
 {
-    $chunks  = [];
-    $prevKey = null;
+    $mode = Mode::check_mode($mode, $input);
 
-    foreach ($input as $value) {
-        $key = $callback($value);
+    $chunks       = [];
+    $prevChunkKey = null;
 
-        if ($chunks !== [] && $prevKey === $key) {
-            $chunks[\count($chunks) - 1][] = $value;
+    foreach ($input as $key => $value) {
+        $chunkKey = $callback($value, $key);
+
+        if ($chunks !== [] && $prevChunkKey === $chunkKey) {
+            $last = \count($chunks) - 1;
+
+            if ($mode === Mode::MODE_ASSOC) {
+                $chunks[$last][$key] = $value;
+            } else {
+                $chunks[$last][] = $value;
+            }
+        } elseif ($mode === Mode::MODE_ASSOC) {
+            $chunks[] = [$key => $value];
         } else {
             $chunks[] = [$value];
-            $prevKey  = $key;
         }
+
+        $prevChunkKey = $chunkKey;
     }
 
     return $chunks;

--- a/tests/ChunkByTest.php
+++ b/tests/ChunkByTest.php
@@ -60,4 +60,68 @@ final class ChunkByTest extends TestCase
 
         $this->assertSame($copy, $input);
     }
+
+    public function testChunkByOnAssocWithAutoModePreservesKeys(): void
+    {
+        $this->assertSame(
+            [['a' => 1, 'b' => 1], ['c' => 2], ['d' => 3, 'e' => 3]],
+            chunk_by(
+                ['a' => 1, 'b' => 1, 'c' => 2, 'd' => 3, 'e' => 3],
+                fn (int $v): int => $v,
+            ),
+        );
+    }
+
+    public function testChunkByOnAssocWithListModeDropsKeys(): void
+    {
+        $this->assertSame(
+            [[1, 1], [2], [3, 3]],
+            chunk_by(
+                ['a' => 1, 'b' => 1, 'c' => 2, 'd' => 3, 'e' => 3],
+                fn (int $v): int => $v,
+                Mode::MODE_LIST,
+            ),
+        );
+    }
+
+    public function testChunkByOnListWithAssocModeKeepsOriginalIndexes(): void
+    {
+        // MODE_ASSOC では chunk の中でも元の添字を維持し、 詰め直さない。
+        $this->assertSame(
+            [[0 => 1, 1 => 1], [2 => 2], [3 => 3, 4 => 3]],
+            chunk_by([1, 1, 2, 3, 3], fn (int $v): int => $v, Mode::MODE_ASSOC),
+        );
+    }
+
+    public function testChunkByPassesKeyAsSecondArgument(): void
+    {
+        // キーの頭文字が変わる位置で chunk を切る。
+        $this->assertSame(
+            [['ax' => 1, 'ay' => 2], ['bx' => 3], ['cx' => 4, 'cy' => 5]],
+            chunk_by(
+                ['ax' => 1, 'ay' => 2, 'bx' => 3, 'cx' => 4, 'cy' => 5],
+                fn (int $v, string $key): string => $key[0],
+            ),
+        );
+    }
+
+    public function testChunkByOnEmptyArrayReturnsEmptyForEveryMode(): void
+    {
+        /** @var array<string, int> $empty */
+        $empty = [];
+
+        $this->assertSame([], chunk_by($empty, fn (int $v): int => $v, Mode::MODE_AUTO));
+        $this->assertSame([], chunk_by($empty, fn (int $v): int => $v, Mode::MODE_LIST));
+        $this->assertSame([], chunk_by($empty, fn (int $v): int => $v, Mode::MODE_ASSOC));
+    }
+
+    public function testChunkByOnEmptyArrayLiteralReturnsEmptyForEveryMode(): void
+    {
+        // 型注釈の無い空配列リテラルでも PHPStan が戻り値の型を解決できること
+        // (assoc 側に non-empty-array を付けると unresolvableReturnType になる) の回帰テスト。
+        $this->assertSame([], chunk_by([], fn ($v) => $v));
+        $this->assertSame([], chunk_by([], fn ($v) => $v, Mode::MODE_AUTO));
+        $this->assertSame([], chunk_by([], fn ($v) => $v, Mode::MODE_LIST));
+        $this->assertSame([], chunk_by([], fn ($v) => $v, Mode::MODE_ASSOC));
+    }
 }


### PR DESCRIPTION
## 概要（What / Why）
`chunk_by` に `Mode` を追加し、assoc 入力に対応させます。あわせて `$callback` にキーを第 2 引数で渡します。

`chunk_by` は #75 でマージしたときに「associative array は順序保証が無いため非対応」と書きましたが、
**この理由は誤りでした**。PHP の配列は挿入順を保持するので、assoc でも「隣接する要素」は明確に定義できます。撤回します。

## 変更点
- `src/chunk_by.php`
    - `Mode $mode = Mode::MODE_AUTO` を追加。各 chunk の内部が mode に従う (外側は常に list)
    - 入力を `list<V>|array<K, V>` に拡張
    - `$callback` を `callable(V, K): R` にしてキーを第 2 引数で渡す (他の関数と揃える)
    - phpdoc の「順序保証が無いため非対応」を撤回し、Mode の説明と assoc の例に差し替え
- `tests/ChunkByTest.php` — 既存 7 ケースは無変更のまま 6 ケース追加

## 動作確認
- 手動：
    - `chunk_by(['a' => 1, 'b' => 1, 'c' => 2], fn ($v) => $v)` → `[['a' => 1, 'b' => 1], ['c' => 2]]` (AUTO で assoc)
    - 同じ入力に `Mode::MODE_LIST` → `[[1, 1], [2]]`
- 自動：
    - `vendor/bin/php-cs-fixer fix --dry-run --diff` / `vendor/bin/phpstan analyse -c phpstan.neon` / `vendor/bin/phpunit tests`
    - 結果：`OK (110 tests, 120 assertions)` / PHPStan level 10 `[OK] No errors` / CS Fixer `Fixed 0 of 31 files`

## 補足（任意）

### 互換性

`$callback` に第 2 引数が増えますが、PHP は宣言より多い引数を無視するので `fn ($v) => $v` 形の既存呼び出しはそのまま動きます。`$mode` は既定値ありなので既存呼び出しは無変更で通り、**既存の 7 ケースは 1 件も落ちていません**。

### assoc 側の戻り値に `non-empty` を付けていない理由

空の chunk は作らないので `list<non-empty-array<K, V>>` と書きたいところですが、これを入れると
**空配列リテラルを直接渡す呼び出しが PHPStan level 10 で落ちます** (実測)。

```
chunk_by([], fn ($v) => $v);   // function.unresolvableReturnType
```

`non-empty-array<never, never>` が unresolvable になるためです (`non-empty-list<never>` は問題なし — list は値型しか持たないため)。list 側の `non-empty-list<V>` は維持し、assoc 側だけ `array<K, V>` に緩めました。理由は phpdoc にも書いてあります。

型注釈なしの `chunk_by([], ...)` を直接書く回帰テストを入れてあります。

Closes なし (対応 issue はありません。#75 の後追い改善です)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
