### PR TITLE
ci: PHP 8.5 を matrix に追加し、フォーマット検査を lint job に分ける

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,10 +9,16 @@ on:
       - 'tests/**'
       - 'composer.json'
       - 'composer.lock'
+      - '.github/workflows/check.yml'
 
 jobs:
   checks:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.4', '8.5']
 
     steps:
       - name: Checkout
@@ -21,14 +27,18 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           tools: composer
           coverage: none
 
       - name: Install dependencies
         run: composer install --no-progress --prefer-dist --no-interaction
 
+      # php-cs-fixer 3.89 は PHP 8.5 の構文をまだサポートしておらず、8.5 で実行すると
+      # 「supports PHP syntax only up to PHP 8.4」と表示して検査せずに終了する (exit 0)。
+      # 通してしまうと偽の成功になるので、フォーマット検査は 8.4 の 1 回だけ行う。
       - name: Run PHP CS Fixer
+        if: matrix.php == '8.4'
         run: vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run PHPStan

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,9 +9,36 @@ on:
       - 'tests/**'
       - 'composer.json'
       - 'composer.lock'
+      - 'phpstan.neon'
+      - '.php-cs-fixer.dist.php'
       - '.github/workflows/check.yml'
 
 jobs:
+  # フォーマット検査は PHP バージョンに依らないので 1 回だけ行う。
+  # php-cs-fixer 3.89 は PHP 8.5 の構文をまだサポートしておらず、8.5 で実行すると
+  # 「supports PHP syntax only up to PHP 8.4」と表示して検査せずに終了する (exit 0) ため、
+  # matrix に乗せると偽の成功になる。php-cs-fixer が 8.5 をサポートしたら
+  # php-version を上げる (この job を消す必要はない)。
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --no-interaction
+
+      - name: Run PHP CS Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
   checks:
     runs-on: ubuntu-latest
 
@@ -33,13 +60,6 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-progress --prefer-dist --no-interaction
-
-      # php-cs-fixer 3.89 は PHP 8.5 の構文をまだサポートしておらず、8.5 で実行すると
-      # 「supports PHP syntax only up to PHP 8.4」と表示して検査せずに終了する (exit 0)。
-      # 通してしまうと偽の成功になるので、フォーマット検査は 8.4 の 1 回だけ行う。
-      - name: Run PHP CS Fixer
-        if: matrix.php == '8.4'
-        run: vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon


### PR DESCRIPTION
## 概要（What / Why）

CI に PHP 8.5 を追加します。

カリー化 (#76) で入るパイプ演算子のテストは `#[RequiresPhp('>= 8.5')]` が付いているため、**8.4 だけの CI では一度も実行されません**。手元の docker では確認していますが、CI で走らないと退行を検出できません。

## 変更点

```yaml
strategy:
  fail-fast: false
  matrix:
    php: ['8.4', '8.5']
```

- **フォーマット検査は matrix から切り出して独立した `lint` job にしました。** php-cs-fixer 3.89 は PHP 8.5 の構文をまだサポートしておらず、8.5 で走らせると次を表示して**検査せずに `exit 0` で終わります**。通すと偽の成功になります

  ```
  PHP CS Fixer currently supports PHP syntax only up to PHP 8.4, current PHP version: 8.5.8.
  Add Config::setUnsupportedPhpVersionAllowed(true) to allow executions on unsupported PHP versions.
  Such execution may be unstable and you may experience code modified in a wrong way.
  ```

  `Config::setUnsupportedPhpVersionAllowed(true)` を足す手もありますが、公式が「unstable / コードが誤って書き換えられる可能性がある」と明言しているので採りません

- **`paths` に `.github/workflows/check.yml` / `phpstan.neon` / `.php-cs-fixer.dist.php` を追加しました。** workflow 自身の変更で CI が走らないと matrix が動くことをこの PR で検証できませんし、`level: 10` を変えても Check が起動しない状態でした

- `fail-fast: false` にしたので、片方が落ちてももう一方の結果が見えます

`composer.json` の `require.php` は **`>=8.4` のまま**です。カリー化した関数は callable を返すだけなので 8.4 で動き、パイプ構文を使うかは利用者側の PHP バージョン次第です。

## 動作確認

docker `php:8.5-cli` (PHP 8.5.8) で実際に走らせました。

| コマンド | 結果 |
|---|---|
| `composer install --no-progress --prefer-dist --no-interaction` | 成功 (55 packages) |
| `vendor/bin/phpstan analyse -c phpstan.neon` | `[OK] No errors` |
| `vendor/bin/phpunit tests` | `OK (104 tests, 109 assertions)` |
| `vendor/bin/php-cs-fixer fix --dry-run --diff` | **未サポートで検査されず終了** (上記) |

dev 依存は phpstan `^2.1` / phpunit `^12.4` / php-cs-fixer `^3.89` で、8.5 で問題があったのは php-cs-fixer だけです。

## レビューへの対応

| 提案 | 対応 |
|---|---|
| **(中) php-cs-fixer を独立 job に** | **対応しました。** `if: matrix.php == '8.4'` は「matrix に `'8.4'` という文字列が存在すること」への暗黙依存で、将来 matrix を `['8.5', '8.6']` に更新すると **if が全て偽になりフォーマット検査だけが警告なく消えます** (CI は緑のまま)。独立 job なら matrix の中身と無関係に必ず 1 回走ります |
| (小) `paths` に設定ファイルが漏れている | **対応しました。** `phpstan.neon` と `.php-cs-fixer.dist.php` を追加 |
| (小) この PR 単体では 8.5 限定テストが走ることは証明できない | そのとおりです (このブランチに `#[RequiresPhp]` は 0 件)。インフラを先に入れる順序として変更しません。**#76 マージ後に `checks (8.5)` のテスト件数が `checks (8.4)` より多いことを確認します** |
| (nit) コメントに解除条件がない | 独立 job にしたので `if` が消えました。コメントには「php-cs-fixer が 8.5 をサポートしたら `php-version` を上げる (この job を消す必要はない)」と書いてあります |

## 注意

**required status check の名前が変わります。** `checks` → `lint` / `checks (8.4)` / `checks (8.5)`。ブランチ保護で `checks` を必須にしている場合は設定の更新が必要です。`lint` は matrix から独立しているので、今後 PHP バージョンを増減しても名前が変わりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
